### PR TITLE
Improve audio quality and disable stream caching

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -18,7 +18,7 @@ const config = {
   mp3Bitrate: process.env.MP3_BITRATE || '96000',
   mixFrameMs: parseInteger(process.env.MIX_FRAME_MS, 20),
   streamEndpoint: '/stream',
-  headerBufferMaxBytes: 256 * 1024,
+  headerBufferMaxBytes: parseInteger(process.env.HEADER_BUFFER_MAX_BYTES, 64 * 1024),
   keepAliveInterval: 20000,
   audio: {
     sampleRate: 48000,

--- a/src/http/AppServer.js
+++ b/src/http/AppServer.js
@@ -57,9 +57,14 @@ class AppServer {
   handleStreamRequest(req, res) {
     const mimeType = this.config.mimeTypes[this.config.outputFormat] || 'application/octet-stream';
     res.setHeader('Content-Type', mimeType);
-    res.setHeader('Cache-Control', 'no-cache');
+    res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, proxy-revalidate');
+    res.setHeader('Pragma', 'no-cache');
+    res.setHeader('Expires', '0');
+    res.setHeader('Surrogate-Control', 'no-store');
     res.setHeader('Connection', 'keep-alive');
     res.setHeader('Transfer-Encoding', 'chunked');
+    res.setHeader('X-Accel-Buffering', 'no');
+    res.setHeader('Accept-Ranges', 'none');
 
     try {
       req.socket.setNoDelay(true);

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,7 @@ const transcoder = new FfmpegTranscoder({
   sampleRate: config.audio.sampleRate,
   channels: config.audio.channels,
   headerBufferMaxBytes: config.headerBufferMaxBytes,
+  mixFrameMs: config.mixFrameMs,
 });
 transcoder.start(mixer);
 

--- a/src/services/SseService.js
+++ b/src/services/SseService.js
@@ -7,8 +7,12 @@ class SseService {
 
   handleRequest(req, res, { initialState }) {
     res.setHeader('Content-Type', 'text/event-stream');
-    res.setHeader('Cache-Control', 'no-cache');
+    res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, proxy-revalidate');
+    res.setHeader('Pragma', 'no-cache');
+    res.setHeader('Expires', '0');
+    res.setHeader('Surrogate-Control', 'no-store');
     res.setHeader('Connection', 'keep-alive');
+    res.setHeader('X-Accel-Buffering', 'no');
 
     try {
       req.socket.setKeepAlive(true);


### PR DESCRIPTION
## Summary
- Update the PCM mixer to ignore empty inputs and normalize only active speakers to reduce distortion.
- Harden the transcoder by applying ffmpeg resampling/Opus voip settings, tracking frame duration, and only caching the Opus header while exposing a smaller configurable limit.
- Send stronger no-cache headers for the audio stream and SSE endpoints to prevent client buffering loops.

## Testing
- `node -e "require('./src/audio/AudioMixer'); require('./src/audio/FfmpegTranscoder');"`


------
https://chatgpt.com/codex/tasks/task_e_68d38ffb9e48832493d268f6914972ee