### PR TITLE
Fix fragment usage in public page

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -61,7 +61,7 @@
     <div id="app" class="min-h-screen"></div>
 
     <script type="module">
-      import { h, render } from 'https://esm.sh/preact@10.19.2';
+      import { h, render, Fragment } from 'https://esm.sh/preact@10.19.2';
       import { useEffect, useMemo, useState } from 'https://esm.sh/preact@10.19.2/hooks';
       import htm from 'https://esm.sh/htm@3.1.1?deps=preact@10.19.2';
 
@@ -230,7 +230,7 @@
       };
 
       const HomePage = ({ status, lastUpdateLabel, streamInfo, audioKey, speakers, now }) => html`
-        <>
+        <${Fragment}>
           <section
             class="relative overflow-hidden rounded-3xl border border-white/10 bg-white/5 px-8 py-12 shadow-xl shadow-slate-950/50 backdrop-blur-xl"
           >
@@ -309,11 +309,11 @@
             </div>
             <${SpeakersSection} speakers=${speakers} now=${now} />
           </section>
-        </>
+        </${Fragment}>
       `;
 
       const AboutPage = () => html`
-        <>
+        <${Fragment}>
           <section class="space-y-6 rounded-3xl border border-white/10 bg-white/5 px-8 py-12 shadow-xl shadow-slate-950/40 backdrop-blur-xl">
             <p class="text-xs uppercase tracking-[0.35em] text-slate-300">Libre Antenne</p>
             <h1 class="text-4xl font-bold tracking-tight text-white sm:text-5xl">À propos de Libre Antenne</h1>
@@ -385,7 +385,7 @@
               </svg>
             </a>
           </section>
-        </>
+        </${Fragment}>
       `;
 
       const App = () => {


### PR DESCRIPTION
## Summary
- import Preact's Fragment helper in the public client script and replace bare fragments with it to avoid invalid tag names

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d3d5455fb88324a65f8e3f1c0cfefd