### PR TITLE
Add custom live audio player

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -55,6 +55,39 @@
           transform: translateY(0) scale(1);
         }
       }
+
+      @keyframes player-eq {
+        0%,
+        100% {
+          transform: scaleY(0.45);
+          opacity: 0.6;
+        }
+
+        50% {
+          transform: scaleY(1);
+          opacity: 1;
+        }
+      }
+
+      .audio-wave span {
+        animation: player-eq 1.2s ease-in-out infinite;
+        transform-origin: center bottom;
+        display: inline-block;
+        width: 0.3rem;
+        border-radius: 9999px;
+      }
+
+      .audio-wave span:nth-child(2) {
+        animation-delay: 0.2s;
+      }
+
+      .audio-wave span:nth-child(3) {
+        animation-delay: 0.4s;
+      }
+
+      .audio-wave span:nth-child(4) {
+        animation-delay: 0.6s;
+      }
     </style>
   </head>
   <body class="min-h-screen bg-slate-950 text-slate-100 antialiased">
@@ -62,7 +95,7 @@
 
     <script type="module">
       import { h, render, Fragment } from 'https://esm.sh/preact@10.19.2';
-      import { useEffect, useMemo, useState } from 'https://esm.sh/preact@10.19.2/hooks';
+      import { useEffect, useMemo, useRef, useState } from 'https://esm.sh/preact@10.19.2/hooks';
       import htm from 'https://esm.sh/htm@3.1.1?deps=preact@10.19.2';
 
       const html = htm.bind(h);
@@ -229,6 +262,368 @@
         return 'home';
       };
 
+      const AudioPlayer = ({ streamInfo, audioKey, status }) => {
+        const audioRef = useRef(null);
+        const [isPlaying, setIsPlaying] = useState(false);
+        const [isLoading, setIsLoading] = useState(true);
+        const [hasError, setHasError] = useState(false);
+        const [isMuted, setIsMuted] = useState(false);
+        const [volume, setVolume] = useState(0.75);
+        const lastVolumeRef = useRef(0.75);
+
+        const isIgnorablePlayError = (error) => {
+          if (!error) return false;
+          const name = error.name || '';
+          return name === 'AbortError' || name === 'NotAllowedError';
+        };
+
+        useEffect(() => {
+          const audio = audioRef.current;
+          if (!audio) return undefined;
+
+          const handlePlaying = () => {
+            setIsPlaying(true);
+            setIsLoading(false);
+            setHasError(false);
+          };
+
+          const handleWaiting = () => {
+            if (!audio.paused) {
+              setIsLoading(true);
+            }
+          };
+
+          const handlePause = () => {
+            setIsPlaying(false);
+            setIsLoading(false);
+          };
+
+          const handleCanPlay = () => {
+            setIsLoading(false);
+          };
+
+          const handleError = () => {
+            setHasError(true);
+            setIsPlaying(false);
+            setIsLoading(false);
+          };
+
+          const handleEnded = () => {
+            setIsPlaying(false);
+          };
+
+          audio.addEventListener('playing', handlePlaying);
+          audio.addEventListener('waiting', handleWaiting);
+          audio.addEventListener('pause', handlePause);
+          audio.addEventListener('canplay', handleCanPlay);
+          audio.addEventListener('canplaythrough', handleCanPlay);
+          audio.addEventListener('stalled', handleWaiting);
+          audio.addEventListener('suspend', handleWaiting);
+          audio.addEventListener('error', handleError);
+          audio.addEventListener('ended', handleEnded);
+
+          return () => {
+            audio.removeEventListener('playing', handlePlaying);
+            audio.removeEventListener('waiting', handleWaiting);
+            audio.removeEventListener('pause', handlePause);
+            audio.removeEventListener('canplay', handleCanPlay);
+            audio.removeEventListener('canplaythrough', handleCanPlay);
+            audio.removeEventListener('stalled', handleWaiting);
+            audio.removeEventListener('suspend', handleWaiting);
+            audio.removeEventListener('error', handleError);
+            audio.removeEventListener('ended', handleEnded);
+          };
+        }, []);
+
+        useEffect(() => {
+          const audio = audioRef.current;
+          if (!audio) return;
+          audio.volume = Math.min(1, Math.max(0, volume));
+        }, [volume]);
+
+        useEffect(() => {
+          const audio = audioRef.current;
+          if (!audio) return;
+          audio.muted = isMuted;
+        }, [isMuted]);
+
+        useEffect(() => {
+          const audio = audioRef.current;
+          if (!audio) return;
+
+          setHasError(false);
+
+          if (!audio.paused) {
+            audio.pause();
+          }
+          audio.src = streamInfo.path;
+          audio.load();
+          setIsLoading(true);
+
+          const attemptPlay = async () => {
+            try {
+              await audio.play();
+            } catch (error) {
+              console.warn('Lecture automatique bloquée', error);
+              setIsLoading(false);
+            }
+          };
+
+          attemptPlay();
+
+          return () => {
+            audio.pause();
+          };
+        }, [audioKey, streamInfo.path]);
+
+        const togglePlay = () => {
+          const audio = audioRef.current;
+          if (!audio) return;
+
+          if (hasError) {
+            setHasError(false);
+          }
+
+          if (isPlaying) {
+            audio.pause();
+          } else {
+            setIsLoading(true);
+            audio
+              .play()
+              .catch((error) => {
+                if (isIgnorablePlayError(error)) {
+                  setIsLoading(false);
+                  return;
+                }
+                console.error('Impossible de lancer la lecture', error);
+                setHasError(true);
+                setIsLoading(false);
+              });
+          }
+        };
+
+        const handleRetry = () => {
+          const audio = audioRef.current;
+          if (!audio) return;
+
+          setHasError(false);
+          setIsLoading(true);
+
+          if (!audio.paused) {
+            audio.pause();
+          }
+          audio.src = streamInfo.path;
+          audio.load();
+          audio
+            .play()
+            .catch((error) => {
+              if (isIgnorablePlayError(error)) {
+                setIsLoading(false);
+                return;
+              }
+              console.error('La relance du flux a échoué', error);
+              setHasError(true);
+              setIsLoading(false);
+            });
+        };
+
+        const handleVolumeChange = (event) => {
+          const value = Number(event?.target?.value ?? 0) / 100;
+          const nextVolume = Number.isFinite(value) ? Math.min(1, Math.max(0, value)) : 0;
+          setVolume(nextVolume);
+          if (nextVolume === 0) {
+            setIsMuted(true);
+          } else {
+            lastVolumeRef.current = nextVolume;
+            if (isMuted) {
+              setIsMuted(false);
+            }
+          }
+        };
+
+        const toggleMute = () => {
+          if (isMuted || volume === 0) {
+            const restored = lastVolumeRef.current > 0 ? lastVolumeRef.current : 0.5;
+            setVolume(restored);
+            setIsMuted(false);
+          } else {
+            lastVolumeRef.current = volume > 0 ? volume : lastVolumeRef.current;
+            setIsMuted(true);
+          }
+        };
+
+        const renderVolumeIcon = () => {
+          if (hasError) {
+            return html`
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-5 w-5">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m0 3v.008h.008V15H12z" />
+                <path stroke-linecap="round" stroke-linejoin="round" d="M21 12A9 9 0 1 1 3 12a9 9 0 0 1 18 0Z" />
+              </svg>
+            `;
+          }
+
+          if (isMuted || volume === 0) {
+            return html`
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-5 w-5">
+                <path stroke-linecap="round" stroke-linejoin="round" d="m19 5-6 6m0 0-6 6m6-6 6 6m-6-6-6-6" />
+                <path stroke-linecap="round" stroke-linejoin="round" d="M4 9v6h3.586L13 18.414V5.586L7.586 11H4Z" />
+              </svg>
+            `;
+          }
+
+          if (volume < 0.45) {
+            return html`
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-5 w-5">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M4 9v6h3.586L13 18.414V5.586L7.586 11H4Z" />
+                <path stroke-linecap="round" stroke-linejoin="round" d="M16.5 9.75a2.25 2.25 0 0 1 0 4.5" />
+              </svg>
+            `;
+          }
+
+          return html`
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-5 w-5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M4 9v6h3.586L13 18.414V5.586L7.586 11H4Z" />
+              <path stroke-linecap="round" stroke-linejoin="round" d="M16.5 8.25a3.75 3.75 0 0 1 0 7.5" />
+              <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 6a6 6 0 0 1 0 12" />
+            </svg>
+          `;
+        };
+
+        const statusConfig = STATUS_LABELS[status] ?? STATUS_LABELS.connecting;
+        const statusText = hasError
+          ? 'Flux indisponible. Relance le flux pour réessayer.'
+          : isLoading
+          ? 'Connexion au flux…'
+          : isPlaying
+          ? 'Lecture en cours'
+          : 'En pause';
+
+        return html`
+          <div class="relative mt-6 overflow-hidden rounded-2xl border border-white/10 bg-slate-950/80 p-6 shadow-2xl shadow-slate-950/60 backdrop-blur">
+            <div class="pointer-events-none absolute -left-32 top-[-8rem] h-72 w-72 rounded-full bg-fuchsia-500/25 blur-3xl"></div>
+            <div class="pointer-events-none absolute -right-36 bottom-[-10rem] h-80 w-80 rounded-full bg-indigo-500/25 blur-[110px]"></div>
+            <div class="relative flex flex-col gap-6 xl:flex-row xl:items-center xl:justify-between">
+              <div class="flex flex-1 flex-col gap-4 sm:flex-row sm:items-center">
+                <div class="flex items-center gap-5">
+                  <button
+                    type="button"
+                    class="relative flex h-16 w-16 items-center justify-center rounded-full bg-gradient-to-br from-fuchsia-500 via-indigo-500 to-sky-400 text-white shadow-lg shadow-fuchsia-900/40 transition focus:outline-none focus:ring-2 focus:ring-fuchsia-300 focus:ring-offset-2 focus:ring-offset-slate-950 hover:scale-105 disabled:cursor-not-allowed disabled:opacity-60"
+                    aria-label=${isPlaying ? 'Mettre le flux en pause' : 'Lancer la lecture du flux'}
+                    onClick=${togglePlay}
+                    disabled=${isLoading && !isPlaying && !hasError}
+                  >
+                    ${
+                      hasError
+                        ? html`
+                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-7 w-7">
+                              <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m0 3v.008h.008V15H12Z" />
+                              <path stroke-linecap="round" stroke-linejoin="round" d="M21 12A9 9 0 1 1 3 12a9 9 0 0 1 18 0Z" />
+                            </svg>
+                          `
+                        : isLoading && !isPlaying
+                        ? html`<span class="h-6 w-6 animate-spin rounded-full border-2 border-white/70 border-t-transparent"></span>`
+                        : isPlaying
+                        ? html`
+                            <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 24 24" class="h-7 w-7">
+                              <path d="M9 5h3v14H9zM15 5h3v14h-3z" />
+                            </svg>
+                          `
+                        : html`
+                            <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 24 24" class="h-7 w-7">
+                              <path d="M8 5v14l11-7z" />
+                            </svg>
+                          `
+                    }
+                  </button>
+                  <div class="space-y-3">
+                    <div class="flex flex-wrap items-center gap-3">
+                      <span class="inline-flex items-center gap-2 rounded-full border border-emerald-400/40 bg-emerald-400/15 px-3 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-emerald-200">
+                        <span class="relative flex h-2 w-2">
+                          <span class="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-200 opacity-75"></span>
+                          <span class="relative inline-flex h-2 w-2 rounded-full bg-emerald-700"></span>
+                        </span>
+                        En direct
+                      </span>
+                      <span class="rounded-full border border-white/10 bg-white/10 px-3 py-1 text-[0.7rem] font-medium uppercase tracking-[0.35em] text-slate-200">
+                        ${statusConfig.label}
+                      </span>
+                      ${
+                        isPlaying
+                          ? html`<div class="audio-wave flex items-end gap-1 text-fuchsia-200">
+                              <span class="h-4 bg-current"></span>
+                              <span class="h-6 bg-current"></span>
+                              <span class="h-5 bg-current"></span>
+                              <span class="h-7 bg-current"></span>
+                            </div>`
+                          : null
+                      }
+                    </div>
+                    <p class="text-sm text-slate-200">
+                      Libre Antenne diffuse le salon vocal en continu. Branche-toi et profite du chaos nocturne.
+                    </p>
+                    <p class=${`text-xs font-medium ${hasError ? 'text-rose-200' : 'text-slate-300'}`}>${statusText}</p>
+                  </div>
+                </div>
+              </div>
+              <div class="relative w-full max-w-md rounded-2xl border border-white/10 bg-black/40 p-4 backdrop-blur">
+                <div class="flex flex-wrap items-center justify-between gap-2 text-[0.65rem] uppercase tracking-[0.35em] text-slate-300">
+                  <span class="rounded-full border border-fuchsia-400/30 bg-fuchsia-500/10 px-3 py-1 text-fuchsia-100">
+                    ${streamInfo.format === 'mp3' ? 'MP3' : 'OPUS'}
+                  </span>
+                  <span class="truncate text-[0.6rem] text-slate-400">Endpoint : ${streamInfo.path}</span>
+                </div>
+                <div class="mt-4 flex items-center gap-3">
+                  <button
+                    type="button"
+                    class="flex h-10 w-10 items-center justify-center rounded-full border border-white/10 bg-white/5 text-slate-200 transition hover:border-white/30 hover:bg-white/10 hover:text-white focus:outline-none focus:ring-2 focus:ring-fuchsia-300 focus:ring-offset-2 focus:ring-offset-slate-950"
+                    aria-label=${isMuted || volume === 0 ? 'Activer le son' : 'Couper le son'}
+                    onClick=${toggleMute}
+                  >
+                    ${renderVolumeIcon()}
+                  </button>
+                  <input
+                    type="range"
+                    min="0"
+                    max="100"
+                    step="1"
+                    value=${Math.round(volume * 100)}
+                    onInput=${handleVolumeChange}
+                    class="h-1 flex-1 cursor-pointer appearance-none rounded-full bg-white/20 accent-fuchsia-400 focus:outline-none focus:ring-0"
+                    aria-label="Volume"
+                  />
+                  <span class="w-12 text-right text-xs text-slate-300">${Math.round(volume * 100)}%</span>
+                </div>
+              </div>
+            </div>
+            ${
+              hasError
+                ? html`<div class="relative mt-5 flex flex-wrap items-center gap-3 rounded-2xl border border-rose-500/40 bg-rose-500/10 px-4 py-3 text-sm text-rose-100">
+                    <div class="flex items-center gap-2 font-semibold">
+                      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-5 w-5">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m0 3v.008h.008V15H12Z" />
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M21 12A9 9 0 1 1 3 12a9 9 0 0 1 18 0Z" />
+                      </svg>
+                      Flux indisponible
+                    </div>
+                    <button
+                      type="button"
+                      class="inline-flex items-center gap-2 rounded-full border border-rose-200/40 bg-rose-200/10 px-3 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.3em] text-rose-100 transition hover:bg-rose-200/20"
+                      onClick=${handleRetry}
+                    >
+                      Relancer le flux
+                      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-3.5 w-3.5">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992V4.356" />
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M21 12a9 9 0 1 1-3.338-6.961" />
+                      </svg>
+                    </button>
+                  </div>`
+                : null
+            }
+            <audio ref=${audioRef} preload="auto" playsinline crossorigin="anonymous" aria-hidden="true"></audio>
+          </div>
+        `;
+      };
+
       const HomePage = ({ status, lastUpdateLabel, streamInfo, audioKey, speakers, now }) => html`
         <${Fragment}>
           <section
@@ -277,21 +672,8 @@
                   Clique sur lecture si le flux ne démarre pas automatiquement. Volume conseillé : casque 💜
                 </p>
               </div>
-              <div class="flex flex-col items-start gap-2 text-sm text-slate-300 lg:items-end">
-                <span
-                  class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-black/40 px-4 py-1.5 text-xs uppercase tracking-[0.3em] text-fuchsia-200"
-                >
-                  ${streamInfo.format === 'mp3' ? 'MP3' : 'OPUS'}
-                </span>
-                <span class="text-xs text-slate-400">Endpoint : ${streamInfo.path}</span>
-              </div>
             </div>
-            <div class="relative mt-6 overflow-hidden rounded-2xl border border-white/10 bg-black/50 p-4 shadow-2xl shadow-slate-950/60">
-              <audio key=${audioKey} class="w-full accent-fuchsia-400" controls autoplay preload="auto">
-                <source src=${streamInfo.path} type=${streamInfo.mimeType} />
-                Ton navigateur ne supporte pas la balise audio.
-              </audio>
-            </div>
+            <${AudioPlayer} streamInfo=${streamInfo} audioKey=${audioKey} status=${status} />
           </section>
 
           <section class="relative overflow-hidden rounded-3xl border border-white/10 bg-white/5 p-8 backdrop-blur-xl">


### PR DESCRIPTION
## Summary
- build a dedicated `AudioPlayer` Preact component with bespoke controls, live indicator, and reconnection helpers for the stream
- add lightweight CSS animations to complement the new player aesthetics
- integrate the custom player into the home page in place of the default browser audio element

## Testing
- not run (no automated tests provided)


------
https://chatgpt.com/codex/tasks/task_e_68d3d79642ac83248dcb8aeb6bd8588c