### PR TITLE
Remplace du texte par des icônes Lucide dans l'interface

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -116,6 +116,26 @@
     <script type="module">
       import { h, render, Fragment } from 'https://esm.sh/preact@10.19.2';
       import { useEffect, useMemo, useRef, useState } from 'https://esm.sh/preact@10.19.2/hooks';
+      import {
+        Activity,
+        AlertCircle,
+        ArrowRight,
+        Clock3,
+        HeadphonesOff,
+        Menu,
+        MicOff,
+        MonitorPlay,
+        Pause,
+        Play,
+        RefreshCcw,
+        Users,
+        Video,
+        Volume,
+        Volume1,
+        Volume2,
+        VolumeX,
+        X,
+      } from 'https://esm.sh/lucide-preact@0.428.0?deps=preact@10.19.2';
       import htm from 'https://esm.sh/htm@3.1.1?deps=preact@10.19.2';
 
       const html = htm.bind(h);
@@ -214,90 +234,16 @@
 
         const voiceBadges = [];
         if (voiceState.selfMute || voiceState.mute) {
-          voiceBadges.push({
-            key: 'mute',
-            label: 'Micro coupé',
-            icon: html`<svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="1.5"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              class="h-3.5 w-3.5"
-            >
-              <path d="M12 18.75a3.75 3.75 0 0 0 3.75-3.75v-1.086" />
-              <path d="M8.25 8.25V12a3.75 3.75 0 0 0 3.75 3.75" />
-              <path d="M12 5.25c-.621 0-1.214.128-1.75.358" />
-              <path d="m3 3 18 18" />
-              <path d="M15.75 8.25V12c0 .66-.126 1.291-.356 1.867" />
-              <path d="M9.53 9.53A2.25 2.25 0 0 0 12 11.25v-4.5" />
-              <path d="M6.75 11.25a5.25 5.25 0 0 0 10.5 0v-3" />
-              <path d="M12 21v-2.25" />
-            </svg>`
-          });
+          voiceBadges.push({ key: 'mute', label: 'Micro coupé', Icon: MicOff });
         }
         if (voiceState.selfDeaf || voiceState.deaf) {
-          voiceBadges.push({
-            key: 'deaf',
-            label: 'Casque coupé',
-            icon: html`<svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="1.5"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              class="h-3.5 w-3.5"
-            >
-              <path d="M4.5 12a7.5 7.5 0 0 1 15 0" />
-              <path d="M19.5 12V18a2.25 2.25 0 0 1-2.25 2.25H15" />
-              <path d="M4.5 12v6A2.25 2.25 0 0 0 6.75 20.25H9" />
-              <path d="M9 16.5v-3.75" />
-              <path d="M15 16.5v-1.5" />
-              <path d="m3 3 18 18" />
-            </svg>`
-          });
+          voiceBadges.push({ key: 'deaf', label: 'Casque coupé', Icon: HeadphonesOff });
         }
         if (voiceState.streaming) {
-          voiceBadges.push({
-            key: 'stream',
-            label: 'Live partage',
-            icon: html`<svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="1.5"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              class="h-3.5 w-3.5"
-            >
-              <path d="M5.25 5.25h13.5v13.5H5.25z" />
-              <path d="m9.75 9.75 4.5 2.25-4.5 2.25z" />
-            </svg>`
-          });
+          voiceBadges.push({ key: 'stream', label: 'Live partage', Icon: MonitorPlay });
         }
         if (voiceState.video) {
-          voiceBadges.push({
-            key: 'video',
-            label: 'Caméra',
-            icon: html`<svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="1.5"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              class="h-3.5 w-3.5"
-            >
-              <path d="M3.75 7.5h10.5a1.5 1.5 0 0 1 1.5 1.5v6a1.5 1.5 0 0 1-1.5 1.5H3.75A1.5 1.5 0 0 1 2.25 15V9a1.5 1.5 0 0 1 1.5-1.5Z" />
-              <path d="m15.75 10.5 3.75-2.25v7.5L15.75 13.5" />
-            </svg>`
-          });
+          voiceBadges.push({ key: 'video', label: 'Caméra', Icon: Video });
         }
 
         return html`
@@ -336,31 +282,21 @@
                 </div>
                 <div class="flex flex-wrap items-center gap-3 text-xs text-slate-200">
                   <span class="flex items-center gap-1 rounded-full bg-white/10 px-3 py-1 backdrop-blur">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="currentColor"
-                      stroke-width="1.5"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      class="h-3.5 w-3.5"
-                    >
-                      <circle cx="12" cy="12" r="9"></circle>
-                      <path d="M12 7v5l2.5 2.5"></path>
-                    </svg>
+                    <${Clock3} class="h-3.5 w-3.5" aria-hidden="true" />
                     ${secondaryLabel}
                   </span>
                 </div>
                 ${voiceBadges.length
-                  ? html`<div class="flex flex-wrap items-center gap-2 text-[0.65rem] uppercase tracking-[0.25em] text-slate-200/80">
+                  ? html`<div class="flex flex-wrap items-center gap-2 text-slate-200/80">
                       ${voiceBadges.map(
-                        (badge) => html`<span
-                          key=${badge.key}
-                          class="flex items-center gap-1 rounded-full bg-white/10 px-3 py-1 backdrop-blur"
+                        ({ key, label, Icon }) => html`<span
+                          key=${key}
+                          class="inline-flex h-7 w-7 items-center justify-center rounded-full bg-white/10 text-slate-100 backdrop-blur transition hover:bg-white/15"
+                          title=${label}
+                          aria-label=${label}
                         >
-                          ${badge.icon}
-                          <span>${badge.label}</span>
+                          <${Icon} class="h-3.5 w-3.5" aria-hidden="true" />
+                          <span class="sr-only">${label}</span>
                         </span>`,
                       )}
                     </div>`
@@ -375,19 +311,7 @@
           return html`
             <div class="mt-6 flex flex-col items-center justify-center gap-4 rounded-3xl border border-white/10 bg-black/40 px-8 py-12 text-center text-sm text-slate-300 backdrop-blur">
               <div class="flex h-14 w-14 items-center justify-center rounded-full bg-white/10 text-fuchsia-200">
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="1.5"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  class="h-7 w-7"
-                >
-                  <circle cx="12" cy="12" r="9"></circle>
-                  <path d="M12 8v5l3 1.5"></path>
-                </svg>
+                <${Users} class="h-7 w-7" aria-hidden="true" />
               </div>
               <p class="max-w-sm text-base text-slate-300">
                 Aucun participant n'est connecté au salon vocal pour le moment. Dès qu’une personne rejoindra, elle apparaîtra ici.
@@ -608,39 +532,22 @@
 
         const renderVolumeIcon = () => {
           if (hasError) {
-            return html`
-              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-5 w-5">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m0 3v.008h.008V15H12z" />
-                <path stroke-linecap="round" stroke-linejoin="round" d="M21 12A9 9 0 1 1 3 12a9 9 0 0 1 18 0Z" />
-              </svg>
-            `;
+            return html`<${AlertCircle} class="h-5 w-5" aria-hidden="true" />`;
           }
 
           if (isMuted || volume === 0) {
-            return html`
-              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-5 w-5">
-                <path stroke-linecap="round" stroke-linejoin="round" d="m19 5-6 6m0 0-6 6m6-6 6 6m-6-6-6-6" />
-                <path stroke-linecap="round" stroke-linejoin="round" d="M4 9v6h3.586L13 18.414V5.586L7.586 11H4Z" />
-              </svg>
-            `;
+            return html`<${VolumeX} class="h-5 w-5" aria-hidden="true" />`;
           }
 
-          if (volume < 0.45) {
-            return html`
-              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-5 w-5">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M4 9v6h3.586L13 18.414V5.586L7.586 11H4Z" />
-                <path stroke-linecap="round" stroke-linejoin="round" d="M16.5 9.75a2.25 2.25 0 0 1 0 4.5" />
-              </svg>
-            `;
+          if (volume < 0.4) {
+            return html`<${Volume} class="h-5 w-5" aria-hidden="true" />`;
           }
 
-          return html`
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-5 w-5">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M4 9v6h3.586L13 18.414V5.586L7.586 11H4Z" />
-              <path stroke-linecap="round" stroke-linejoin="round" d="M16.5 8.25a3.75 3.75 0 0 1 0 7.5" />
-              <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 6a6 6 0 0 1 0 12" />
-            </svg>
-          `;
+          if (volume < 0.75) {
+            return html`<${Volume1} class="h-5 w-5" aria-hidden="true" />`;
+          }
+
+          return html`<${Volume2} class="h-5 w-5" aria-hidden="true" />`;
         };
 
         const statusConfig = STATUS_LABELS[status] ?? STATUS_LABELS.connecting;
@@ -668,25 +575,12 @@
                   >
                     ${
                       hasError
-                        ? html`
-                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-7 w-7">
-                              <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m0 3v.008h.008V15H12Z" />
-                              <path stroke-linecap="round" stroke-linejoin="round" d="M21 12A9 9 0 1 1 3 12a9 9 0 0 1 18 0Z" />
-                            </svg>
-                          `
+                        ? html`<${AlertCircle} class="h-7 w-7" aria-hidden="true" />`
                         : isLoading && !isPlaying
                         ? html`<span class="h-6 w-6 animate-spin rounded-full border-2 border-white/70 border-t-transparent"></span>`
                         : isPlaying
-                        ? html`
-                            <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 24 24" class="h-7 w-7">
-                              <path d="M9 5h3v14H9zM15 5h3v14h-3z" />
-                            </svg>
-                          `
-                        : html`
-                            <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 24 24" class="h-7 w-7">
-                              <path d="M8 5v14l11-7z" />
-                            </svg>
-                          `
+                        ? html`<${Pause} class="h-7 w-7" aria-hidden="true" />`
+                        : html`<${Play} class="h-7 w-7" aria-hidden="true" />`
                     }
                   </button>
                   <div class="space-y-3">
@@ -753,10 +647,7 @@
               hasError
                 ? html`<div class="relative mt-5 flex flex-wrap items-center gap-3 rounded-2xl border border-rose-500/40 bg-rose-500/10 px-4 py-3 text-sm text-rose-100">
                     <div class="flex items-center gap-2 font-semibold">
-                      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-5 w-5">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m0 3v.008h.008V15H12Z" />
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M21 12A9 9 0 1 1 3 12a9 9 0 0 1 18 0Z" />
-                      </svg>
+                      <${AlertCircle} class="h-5 w-5" aria-hidden="true" />
                       Flux indisponible
                     </div>
                     <button
@@ -765,10 +656,7 @@
                       onClick=${handleRetry}
                     >
                       Relancer le flux
-                      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-3.5 w-3.5">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992V4.356" />
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M21 12a9 9 0 1 1-3.338-6.961" />
-                      </svg>
+                      <${RefreshCcw} class="h-3.5 w-3.5" aria-hidden="true" />
                     </button>
                   </div>`
                 : null
@@ -805,16 +693,7 @@
                   rel="noopener noreferrer"
                 >
                   Rejoindre le Discord
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke-width="1.5"
-                    stroke="currentColor"
-                    class="h-4 w-4"
-                  >
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M5.25 12h13.5m0 0-5.25-5.25M18.75 12l-5.25 5.25" />
-                  </svg>
+                  <${ArrowRight} class="h-4 w-4" aria-hidden="true" />
                 </a>
               </div>
               <div class="flex flex-col items-start gap-3 text-left lg:items-end lg:text-right">
@@ -845,9 +724,19 @@
                   Toutes les personnes connectées au salon vocal apparaissent ici et l’animation se déclenche dès qu’une voix est détectée.
                 </p>
               </div>
-              <div class="flex items-center gap-2 rounded-full border border-white/10 bg-black/40 px-4 py-1.5 text-xs uppercase tracking-[0.3em] text-indigo-200">
-                <span class="h-2 w-2 rounded-full bg-indigo-300"></span>
-                ${connectedCount} connectés · ${activeSpeakersCount} en direct
+              <div class="flex items-center gap-3 rounded-full border border-white/10 bg-black/40 px-4 py-1.5 text-xs tracking-[0.3em] text-indigo-200">
+                <span class="sr-only">Statistiques vocales</span>
+                <span class="flex items-center gap-1">
+                  <${Users} class="h-3.5 w-3.5" aria-hidden="true" />
+                  <span aria-hidden="true" class="text-sm font-semibold tracking-normal">${connectedCount}</span>
+                  <span class="sr-only">personnes connectées</span>
+                </span>
+                <span aria-hidden="true" class="text-indigo-300">·</span>
+                <span class="flex items-center gap-1">
+                  <${Activity} class="h-3.5 w-3.5" aria-hidden="true" />
+                  <span aria-hidden="true" class="text-sm font-semibold tracking-normal">${activeSpeakersCount}</span>
+                  <span class="sr-only">personnes en direct</span>
+                </span>
               </div>
             </div>
             <${SpeakersSection} speakers=${speakers} now=${now} />
@@ -917,16 +806,7 @@
               rel="noopener noreferrer"
             >
               Rejoindre le Discord
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke-width="1.5"
-                stroke="currentColor"
-                class="h-4 w-4"
-              >
-                <path stroke-linecap="round" stroke-linejoin="round" d="M5.25 12h13.5m0 0-5.25-5.25M18.75 12l-5.25 5.25" />
-              </svg>
+              <${ArrowRight} class="h-4 w-4" aria-hidden="true" />
             </a>
           </section>
         </${Fragment}>
@@ -1139,30 +1019,8 @@
                   >
                     ${
                       menuOpen
-                        ? html`
-                            <svg
-                              xmlns="http://www.w3.org/2000/svg"
-                              fill="none"
-                              viewBox="0 0 24 24"
-                              stroke-width="1.5"
-                              stroke="currentColor"
-                              class="h-5 w-5"
-                            >
-                              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
-                            </svg>
-                          `
-                        : html`
-                            <svg
-                              xmlns="http://www.w3.org/2000/svg"
-                              fill="none"
-                              viewBox="0 0 24 24"
-                              stroke-width="1.5"
-                              stroke="currentColor"
-                              class="h-5 w-5"
-                            >
-                              <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
-                            </svg>
-                          `
+                        ? html`<${X} class="h-5 w-5" aria-hidden="true" />`
+                        : html`<${Menu} class="h-5 w-5" aria-hidden="true" />`
                     }
                   </button>
                 </div>


### PR DESCRIPTION
## Summary
- intègre la bibliothèque lucide-preact pour remplacer les SVG en dur et les libellés textuels par des icônes
- remplace les badges texte de la liste des intervenants vocaux par des pictogrammes avec étiquettes accessibles
- harmonise les contrôles (player, navigation, boutons d’action) avec les icônes Lucide

## Testing
- not run (non applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d43f471fac83249191a5b260e952cd