### PR TITLE
fix: use available headphones icon

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -121,7 +121,7 @@
         AlertCircle,
         ArrowRight,
         Clock3,
-        HeadphonesOff,
+        Headphones,
         Menu,
         MicOff,
         MonitorPlay,
@@ -237,7 +237,7 @@
           voiceBadges.push({ key: 'mute', label: 'Micro coupé', Icon: MicOff });
         }
         if (voiceState.selfDeaf || voiceState.deaf) {
-          voiceBadges.push({ key: 'deaf', label: 'Casque coupé', Icon: HeadphonesOff });
+          voiceBadges.push({ key: 'deaf', label: 'Casque coupé', Icon: Headphones });
         }
         if (voiceState.streaming) {
           voiceBadges.push({ key: 'stream', label: 'Live partage', Icon: MonitorPlay });


### PR DESCRIPTION
## Summary
- replace the unavailable `HeadphonesOff` lucide icon with `Headphones` to resolve the runtime import error

## Testing
- not run (frontend change only)


------
https://chatgpt.com/codex/tasks/task_e_68d441598a088324a2e8bbdc3ef73779