### PR TITLE
Ensure player play button remains perfectly circular

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -613,7 +613,7 @@
                 <div class="flex items-center gap-5">
                   <button
                     type="button"
-                    class="relative flex h-24 w-24 items-center justify-center rounded-full bg-gradient-to-br from-fuchsia-500 via-indigo-500 to-sky-400 text-white shadow-lg shadow-fuchsia-900/40 transition focus:outline-none focus:ring-2 focus:ring-fuchsia-300 focus:ring-offset-2 focus:ring-offset-slate-950 hover:scale-105 disabled:cursor-not-allowed disabled:opacity-60"
+                    class="relative flex aspect-square w-24 shrink-0 items-center justify-center overflow-hidden rounded-full bg-gradient-to-br from-fuchsia-500 via-indigo-500 to-sky-400 text-white shadow-lg shadow-fuchsia-900/40 transition focus:outline-none focus:ring-2 focus:ring-fuchsia-300 focus:ring-offset-2 focus:ring-offset-slate-950 hover:scale-105 disabled:cursor-not-allowed disabled:opacity-60"
                     aria-label=${isPlaying ? 'Mettre le flux en pause' : 'Lancer la lecture du flux'}
                     onClick=${togglePlay}
                     disabled=${isLoading && !isPlaying && !hasError}


### PR DESCRIPTION
## Summary
- force the play button wrapper to keep a strict 1:1 ratio and stay fixed in size
- prevent flexbox from distorting the control by making it non-shrinking and clipping overflow

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d4449637148324853ca24a9aaaf8a3