### PR TITLE
Improve speaker cards motion and icon labels

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -115,7 +115,7 @@
 
     <script type="module">
       import { h, render, Fragment } from 'https://esm.sh/preact@10.19.2';
-      import { useEffect, useMemo, useRef, useState } from 'https://esm.sh/preact@10.19.2/hooks';
+      import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'https://esm.sh/preact@10.19.2/hooks';
       import {
         Activity,
         AlertCircle,
@@ -147,7 +147,7 @@
           dot: 'bg-amber-300',
         },
         connected: {
-          label: null,
+          label: 'En direct',
           srLabel: 'En direct',
           Icon: Activity,
           ring: 'bg-emerald-400/15 text-emerald-200 border-emerald-400/40',
@@ -192,18 +192,67 @@
 
       const StatusBadge = ({ status }) => {
         const config = STATUS_LABELS[status] ?? STATUS_LABELS.connecting;
+        const text = config.label ?? config.srLabel ?? 'Statut';
         return html`
           <div class=${`flex items-center gap-2 rounded-full border px-4 py-2 text-sm font-medium backdrop-blur ${config.ring}`}>
             <span class=${`h-2.5 w-2.5 rounded-full shadow-md ${config.dot}`}></span>
-            ${config.Icon
-              ? html`<span class="sr-only">${config.srLabel ?? 'Statut'}</span>
-                  <${config.Icon} class="h-4 w-4" aria-hidden="true" />`
-              : html`<span>${config.label}</span>`}
+            <span class="flex items-center gap-1">
+              ${config.Icon ? html`<${config.Icon} class="h-4 w-4" aria-hidden="true" />` : null}
+              <span>${text}</span>
+            </span>
           </div>
         `;
       };
 
-      const SpeakerCard = ({ speaker, now }) => {
+      const useSmoothReorder = (ids) => {
+        const containerRef = useRef(null);
+        const positionsRef = useRef(new Map());
+
+        useLayoutEffect(() => {
+          if (typeof window === 'undefined') return;
+          const container = containerRef.current;
+          if (!container) return;
+
+          const prefersReducedMotion = window.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches;
+          const elements = Array.from(container.querySelectorAll('[data-speaker-id]'));
+          const nextPositions = new Map();
+
+          for (const element of elements) {
+            const id = element.getAttribute('data-speaker-id');
+            if (!id) continue;
+            nextPositions.set(id, element.getBoundingClientRect());
+          }
+
+          if (!prefersReducedMotion) {
+            for (const element of elements) {
+              const id = element.getAttribute('data-speaker-id');
+              if (!id) continue;
+              const previous = positionsRef.current.get(id);
+              const current = nextPositions.get(id);
+              if (!previous || !current) continue;
+              const deltaX = previous.left - current.left;
+              const deltaY = previous.top - current.top;
+              if ((deltaX === 0 && deltaY === 0) || typeof element.animate !== 'function') continue;
+              element.animate(
+                [
+                  { transform: `translate(${deltaX}px, ${deltaY}px)` },
+                  { transform: 'translate(0, 0)' },
+                ],
+                {
+                  duration: 450,
+                  easing: 'cubic-bezier(0.16, 1, 0.3, 1)',
+                },
+              );
+            }
+          }
+
+          positionsRef.current = nextPositions;
+        }, [ids.join('|')]);
+
+        return containerRef;
+      };
+
+      const SpeakerCard = ({ speaker, now, cardId }) => {
         const voiceState = speaker.voiceState ?? {};
         const isSpeaking = Boolean(speaker.isSpeaking);
         const duration = isSpeaking && speaker.startedAt ? formatDuration(now - speaker.startedAt) : null;
@@ -218,6 +267,7 @@
           if (isSpeaking) {
             return {
               srLabel: 'En live',
+              label: 'Live',
               Icon: Activity,
               classes: 'bg-emerald-500 text-emerald-900',
               ping: true,
@@ -227,6 +277,7 @@
           if (voiceState.selfMute || voiceState.mute) {
             return {
               srLabel: 'Micro coupé',
+              label: 'Muet',
               Icon: MicOff,
               classes: 'bg-slate-200/90 text-slate-900',
               ping: false,
@@ -236,6 +287,7 @@
           if (voiceState.selfDeaf || voiceState.deaf) {
             return {
               srLabel: 'Casque coupé',
+              label: 'Casque',
               Icon: Headphones,
               classes: 'bg-slate-200/90 text-slate-900',
               ping: false,
@@ -244,6 +296,7 @@
           }
           return {
             srLabel: 'À l’écoute',
+            label: 'Écoute',
             Icon: Headphones,
             classes: 'bg-slate-200/90 text-slate-900',
             ping: false,
@@ -277,13 +330,13 @@
 
         const voiceBadges = [];
         if (voiceState.selfMute || voiceState.mute) {
-          voiceBadges.push({ key: 'mute', label: 'Micro coupé', Icon: MicOff });
+          voiceBadges.push({ key: 'mute', label: 'Muet', Icon: MicOff });
         }
         if (voiceState.selfDeaf || voiceState.deaf) {
-          voiceBadges.push({ key: 'deaf', label: 'Casque coupé', Icon: Headphones });
+          voiceBadges.push({ key: 'deaf', label: 'Casque off', Icon: Headphones });
         }
         if (voiceState.streaming) {
-          voiceBadges.push({ key: 'stream', label: 'Live partage', Icon: MonitorPlay });
+          voiceBadges.push({ key: 'stream', label: 'Partage', Icon: MonitorPlay });
         }
         if (voiceState.video) {
           voiceBadges.push({ key: 'video', label: 'Caméra', Icon: Video });
@@ -293,6 +346,7 @@
           <article
             class=${`speaker-card group relative overflow-hidden rounded-3xl border ${cardAccentClass} p-5 shadow-xl shadow-indigo-900/30 transition duration-300 hover:border-fuchsia-400/60 hover:shadow-glow`}
             data-state=${cardState}
+            data-speaker-id=${cardId ?? speaker.id}
           >
             <div class="absolute -right-14 -top-14 h-32 w-32 rounded-full bg-fuchsia-500/40 blur-3xl transition-opacity duration-300 group-hover:opacity-100"></div>
             <div class="relative flex items-center gap-5">
@@ -305,7 +359,7 @@
                   loading="lazy"
                 />
                 <div
-                  class=${`absolute -bottom-1 -right-1 flex items-center gap-1 rounded-full px-2 py-0.5 text-[0.65rem] font-semibold uppercase tracking-wider shadow-lg ${badgeConfig.classes}`}
+                  class=${`absolute -bottom-1 -right-1 flex items-center gap-1 rounded-full px-2 py-0.5 text-[0.6rem] font-semibold uppercase tracking-wider shadow-lg ${badgeConfig.classes}`}
                 >
                   <span class="relative flex h-2 w-2">
                     <span
@@ -317,6 +371,7 @@
                   </span>
                   <span class="sr-only">${badgeConfig.srLabel}</span>
                   <${badgeConfig.Icon} class="h-3.5 w-3.5" aria-hidden="true" />
+                  <span aria-hidden="true">${badgeConfig.label}</span>
                 </div>
               </div>
               <div class="relative flex flex-1 flex-col gap-2">
@@ -336,12 +391,12 @@
                       ${voiceBadges.map(
                         ({ key, label, Icon }) => html`<span
                           key=${key}
-                          class="inline-flex h-7 w-7 items-center justify-center rounded-full bg-white/10 text-slate-100 backdrop-blur transition hover:bg-white/15"
+                          class="inline-flex items-center gap-1 rounded-full bg-white/10 px-2.5 py-1 text-[0.65rem] font-medium uppercase tracking-[0.2em] text-slate-100 backdrop-blur transition hover:bg-white/15"
                           title=${label}
                           aria-label=${label}
                         >
                           <${Icon} class="h-3.5 w-3.5" aria-hidden="true" />
-                          <span class="sr-only">${label}</span>
+                          <span aria-hidden="true">${label}</span>
                         </span>`,
                       )}
                     </div>`
@@ -352,6 +407,9 @@
         `;
       };
       const SpeakersSection = ({ speakers, now }) => {
+        const speakerIds = useMemo(() => speakers.map((speaker) => String(speaker.id ?? '')), [speakers]);
+        const containerRef = useSmoothReorder(speakerIds);
+
         if (!speakers.length) {
           return html`
             <div class="mt-6 flex flex-col items-center justify-center gap-4 rounded-3xl border border-white/10 bg-black/40 px-8 py-12 text-center text-sm text-slate-300 backdrop-blur">
@@ -366,8 +424,8 @@
         }
 
         return html`
-          <div class="mt-6 grid gap-6 sm:grid-cols-2">
-            ${speakers.map((speaker) => html`<${SpeakerCard} key=${speaker.id} speaker=${speaker} now=${now} />`)}
+          <div ref=${containerRef} class="mt-6 grid gap-6 sm:grid-cols-2">
+            ${speakers.map((speaker) => html`<${SpeakerCard} key=${speaker.id} speaker=${speaker} now=${now} cardId=${speaker.id} />`)}
           </div>
         `;
       };
@@ -635,13 +693,15 @@
                           <span class="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-200 opacity-75"></span>
                           <span class="relative inline-flex h-2 w-2 rounded-full bg-emerald-700"></span>
                         </span>
-                        <span class="sr-only">En direct</span>
                         <${Activity} class="h-3.5 w-3.5" aria-hidden="true" />
+                        <span>En direct</span>
                       </span>
                       <span class="rounded-full border border-white/10 bg-white/10 px-3 py-1 text-[0.7rem] font-medium uppercase tracking-[0.35em] text-slate-200">
                         ${statusConfig.Icon
-                          ? html`<span class="sr-only">${statusConfig.srLabel ?? 'Statut'}</span>
-                              <${statusConfig.Icon} class="h-3.5 w-3.5" aria-hidden="true" />`
+                          ? html`<span class="flex items-center gap-1">
+                                <${statusConfig.Icon} class="h-3.5 w-3.5" aria-hidden="true" />
+                                <span>${statusConfig.label ?? statusConfig.srLabel ?? 'Statut'}</span>
+                              </span>`
                           : statusConfig.label}
                       </span>
                       ${
@@ -775,15 +835,17 @@
               </div>
               <div class="flex items-center gap-3 rounded-full border border-white/10 bg-black/40 px-4 py-1.5 text-xs tracking-[0.3em] text-indigo-200">
                 <span class="sr-only">Statistiques vocales</span>
-                <span class="flex items-center gap-1">
+                <span class="flex items-center gap-2">
                   <${Users} class="h-3.5 w-3.5" aria-hidden="true" />
                   <span aria-hidden="true" class="text-sm font-semibold tracking-normal">${connectedCount}</span>
+                  <span aria-hidden="true" class="text-[0.6rem] font-semibold uppercase tracking-[0.35em] text-indigo-200/80">Connectés</span>
                   <span class="sr-only">personnes connectées</span>
                 </span>
                 <span aria-hidden="true" class="text-indigo-300">·</span>
-                <span class="flex items-center gap-1">
+                <span class="flex items-center gap-2">
                   <${Activity} class="h-3.5 w-3.5" aria-hidden="true" />
                   <span aria-hidden="true" class="text-sm font-semibold tracking-normal">${activeSpeakersCount}</span>
+                  <span aria-hidden="true" class="text-[0.6rem] font-semibold uppercase tracking-[0.35em] text-indigo-200/80">En live</span>
                   <span class="sr-only">personnes en direct</span>
                 </span>
               </div>


### PR DESCRIPTION
## Summary
- add smooth FLIP-style animation when speaker cards reorder to make transitions visible
- surface short text labels next to key UI icons including status, live badge, and voice state chips
- enrich speaker indicators with concise badges so icon meanings remain clear

## Testing
- no tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d451a61e88832492dda1b5f9f40c48