### PR TITLE
Garantir un tri alphabétique stable des cartes utilisateurs

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1063,22 +1063,19 @@
             voiceState: participant.voiceState ?? {},
           }));
           values.sort((a, b) => {
-            if (a.isSpeaking !== b.isSpeaking) {
-              return a.isSpeaking ? -1 : 1;
+            const nameA = (a.displayName || a.username || '').trim();
+            const nameB = (b.displayName || b.username || '').trim();
+            const normalizedA = nameA.toLocaleLowerCase('fr-FR');
+            const normalizedB = nameB.toLocaleLowerCase('fr-FR');
+            const nameComparison = normalizedA.localeCompare(normalizedB, 'fr', {
+              sensitivity: 'base',
+            });
+            if (nameComparison !== 0) {
+              return nameComparison;
             }
-            const aLast = a.lastSpokeAt || 0;
-            const bLast = b.lastSpokeAt || 0;
-            if (aLast !== bLast) {
-              return bLast - aLast;
-            }
-            const aJoined = a.joinedAt || 0;
-            const bJoined = b.joinedAt || 0;
-            if (aJoined !== bJoined) {
-              return aJoined - bJoined;
-            }
-            const nameA = (a.displayName || a.username || '').toLocaleLowerCase('fr-FR');
-            const nameB = (b.displayName || b.username || '').toLocaleLowerCase('fr-FR');
-            return nameA.localeCompare(nameB);
+            const idA = String(a.id ?? '');
+            const idB = String(b.id ?? '');
+            return idA.localeCompare(idB);
           });
           return values;
         }, [participantsMap]);


### PR DESCRIPTION
## Summary
- trier les participants côté client uniquement par nom afin de conserver un ordre stable
- normaliser les noms (trim et insensibilité à la casse) et ajouter un tiebreaker sur l'identifiant

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4d3fde2b4832486faa93f26c7e7a8