### PR TITLE
Add automatic stream health monitoring and restart

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -37,6 +37,32 @@ config.audio.frameSamples = Math.floor(
 config.audio.frameBytes =
   config.audio.frameSamples * config.audio.channels * config.audio.bytesPerSample;
 
+const defaultMinDecodedBytes = config.audio.frameBytes * 3;
+
+config.healthCheck = {
+  host: process.env.STREAM_HEALTH_HOST || '127.0.0.1',
+  intervalMs: parseInteger(process.env.STREAM_HEALTH_INTERVAL_MS, 15000),
+  connectTimeoutMs: parseInteger(
+    process.env.STREAM_HEALTH_CONNECT_TIMEOUT_MS,
+    5000,
+  ),
+  playbackTimeoutMs: parseInteger(
+    process.env.STREAM_HEALTH_PLAYBACK_TIMEOUT_MS,
+    8000,
+  ),
+  minDecodedBytes: Math.max(
+    config.audio.frameBytes,
+    parseInteger(
+      process.env.STREAM_HEALTH_MIN_DECODED_BYTES,
+      defaultMinDecodedBytes,
+    ),
+  ),
+  failureThreshold: Math.max(
+    1,
+    parseInteger(process.env.STREAM_HEALTH_FAILURE_THRESHOLD, 2),
+  ),
+};
+
 if (!config.botToken) {
   console.error('BOT_TOKEN is required in the environment');
   process.exit(1);

--- a/src/index.js
+++ b/src/index.js
@@ -5,112 +5,267 @@ const AppServer = require('./http/AppServer');
 const SseService = require('./services/SseService');
 const SpeakerTracker = require('./services/SpeakerTracker');
 const DiscordAudioBridge = require('./discord/DiscordAudioBridge');
+const StreamHealthMonitor = require('./services/StreamHealthMonitor');
 
-const mixer = new AudioMixer({
-  frameBytes: config.audio.frameBytes,
-  mixFrameMs: config.mixFrameMs,
-  bytesPerSample: config.audio.bytesPerSample,
-});
-mixer.start();
+let runtimeContext = null;
+let healthMonitor = null;
+let shuttingDown = false;
+let restarting = false;
 
-const transcoder = new FfmpegTranscoder({
-  ffmpegPath: config.ffmpegPath,
-  outputFormat: config.outputFormat,
-  opusBitrate: config.opusBitrate,
-  mp3Bitrate: config.mp3Bitrate,
-  sampleRate: config.audio.sampleRate,
-  channels: config.audio.channels,
-  headerBufferMaxBytes: config.headerBufferMaxBytes,
-  mixFrameMs: config.mixFrameMs,
-});
-transcoder.start(mixer);
+async function startRuntime() {
+  const mixer = new AudioMixer({
+    frameBytes: config.audio.frameBytes,
+    mixFrameMs: config.mixFrameMs,
+    bytesPerSample: config.audio.bytesPerSample,
+  });
+  mixer.start();
 
-const statsLogInterval = setInterval(() => {
-  const statsSnapshot = {
-    ...mixer.stats,
-    sources: mixer.sources.size,
-    ffmpegPid: transcoder.getCurrentProcessPid(),
+  const transcoder = new FfmpegTranscoder({
+    ffmpegPath: config.ffmpegPath,
+    outputFormat: config.outputFormat,
+    opusBitrate: config.opusBitrate,
+    mp3Bitrate: config.mp3Bitrate,
+    sampleRate: config.audio.sampleRate,
+    channels: config.audio.channels,
+    headerBufferMaxBytes: config.headerBufferMaxBytes,
+    mixFrameMs: config.mixFrameMs,
+  });
+  transcoder.start(mixer);
+
+  const statsLogInterval = setInterval(() => {
+    const statsSnapshot = {
+      ...mixer.stats,
+      sources: mixer.sources.size,
+      ffmpegPid: transcoder.getCurrentProcessPid(),
+    };
+
+    console.log('MIX STATS:', statsSnapshot);
+  }, 5000);
+
+  if (typeof statsLogInterval.unref === 'function') {
+    statsLogInterval.unref();
+  }
+
+  const sseService = new SseService({
+    streamInfoProvider: () => ({
+      format: config.outputFormat,
+      path: config.streamEndpoint,
+      mimeType: config.mimeTypes[config.outputFormat] || 'application/octet-stream',
+    }),
+    keepAliveInterval: config.keepAliveInterval,
+  });
+
+  const speakerTracker = new SpeakerTracker({ sseService });
+
+  const discordBridge = new DiscordAudioBridge({
+    config,
+    mixer,
+    speakerTracker,
+  });
+
+  try {
+    await discordBridge.login();
+  } catch (error) {
+    console.error('Discord login failed', error);
+    await stopRuntime({
+      mixer,
+      transcoder,
+      statsLogInterval,
+      sseService,
+      speakerTracker,
+      discordBridge,
+      appServer: null,
+    });
+    throw error;
+  }
+
+  const appServer = new AppServer({
+    config,
+    transcoder,
+    speakerTracker,
+    sseService,
+  });
+  appServer.start();
+
+  return {
+    mixer,
+    transcoder,
+    statsLogInterval,
+    sseService,
+    speakerTracker,
+    discordBridge,
+    appServer,
   };
-
-  console.log('MIX STATS:', statsSnapshot);
-}, 5000);
-
-if (typeof statsLogInterval.unref === 'function') {
-  statsLogInterval.unref();
 }
 
-const sseService = new SseService({
-  streamInfoProvider: () => ({
-    format: config.outputFormat,
-    path: config.streamEndpoint,
-    mimeType: config.mimeTypes[config.outputFormat] || 'application/octet-stream',
-  }),
-  keepAliveInterval: config.keepAliveInterval,
-});
+async function stopRuntime(context) {
+  if (!context) {
+    return;
+  }
 
-const speakerTracker = new SpeakerTracker({ sseService });
+  const {
+    statsLogInterval,
+    mixer,
+    transcoder,
+    sseService,
+    speakerTracker,
+    appServer,
+    discordBridge,
+  } = context;
 
-const discordBridge = new DiscordAudioBridge({
-  config,
-  mixer,
-  speakerTracker,
-});
-
-discordBridge.login().catch((error) => {
-  console.error('Discord login failed', error);
-  process.exit(1);
-});
-
-const appServer = new AppServer({
-  config,
-  transcoder,
-  speakerTracker,
-  sseService,
-});
-appServer.start();
-
-function shutdown() {
-  console.log('Shutting down...');
   try {
-    clearInterval(statsLogInterval);
+    if (statsLogInterval) {
+      clearInterval(statsLogInterval);
+    }
   } catch (error) {
     console.warn('Error while clearing stats interval', error);
   }
+
   try {
-    mixer.stop();
+    mixer?.stop();
   } catch (error) {
     console.warn('Error while stopping mixer', error);
   }
 
   try {
-    transcoder.stop();
+    transcoder?.stop();
   } catch (error) {
     console.warn('Error while stopping transcoder', error);
   }
 
   try {
-    sseService.closeAll();
+    sseService?.closeAll();
   } catch (error) {
     console.warn('Error while closing SSE connections', error);
   }
 
   try {
-    speakerTracker.clear();
+    speakerTracker?.clear();
   } catch (error) {
     console.warn('Error while clearing speaker tracker', error);
   }
 
   try {
-    appServer.stop();
+    appServer?.stop();
   } catch (error) {
     console.warn('Error while stopping HTTP server', error);
   }
 
-  discordBridge
-    .destroy()
-    .catch((error) => console.warn('Error while destroying Discord bridge', error))
-    .finally(() => process.exit(0));
+  if (discordBridge) {
+    try {
+      await discordBridge.destroy();
+    } catch (error) {
+      console.warn('Error while destroying Discord bridge', error);
+    }
+  }
 }
 
-process.on('SIGINT', shutdown);
-process.on('SIGTERM', shutdown);
+async function restartRuntime(info = {}) {
+  if (restarting || shuttingDown) {
+    return;
+  }
+
+  restarting = true;
+  const reason = info.reason || 'unknown reason';
+  console.warn(`Stream health issue detected (${reason}). Restarting streaming pipeline...`);
+  if (info.error) {
+    console.warn('Underlying health check error:', info.error);
+  }
+
+  try {
+    if (healthMonitor) {
+      await healthMonitor.stop();
+    }
+
+    await stopRuntime(runtimeContext);
+    runtimeContext = null;
+    runtimeContext = await startRuntime();
+
+    if (healthMonitor && !shuttingDown) {
+      healthMonitor.start();
+    }
+
+    console.log('Streaming pipeline restarted successfully.');
+  } catch (error) {
+    console.error('Failed to restart streaming pipeline', error);
+    process.exit(1);
+  } finally {
+    restarting = false;
+  }
+}
+
+async function shutdown(exitCode = 0) {
+  if (shuttingDown) {
+    return;
+  }
+
+  shuttingDown = true;
+  console.log('Shutting down...');
+
+  try {
+    if (healthMonitor) {
+      await healthMonitor.stop();
+    }
+  } catch (error) {
+    console.warn('Error while stopping health monitor', error);
+  }
+
+  try {
+    await stopRuntime(runtimeContext);
+    runtimeContext = null;
+  } catch (error) {
+    console.warn('Error while stopping runtime', error);
+  }
+
+  process.exit(exitCode);
+}
+
+(async () => {
+  try {
+    runtimeContext = await startRuntime();
+  } catch (error) {
+    console.error('Application failed to start', error);
+    process.exit(1);
+  }
+
+  healthMonitor = new StreamHealthMonitor({
+    config,
+    checkIntervalMs: config.healthCheck.intervalMs,
+    connectTimeoutMs: config.healthCheck.connectTimeoutMs,
+    playbackTimeoutMs: config.healthCheck.playbackTimeoutMs,
+    minDecodedBytes: config.healthCheck.minDecodedBytes,
+    failureThreshold: config.healthCheck.failureThreshold,
+    onUnhealthy: (info) => {
+      restartRuntime(info).catch((error) => {
+        console.error('Unhandled error while restarting runtime', error);
+        process.exit(1);
+      });
+    },
+  });
+
+  healthMonitor.on('healthy', () => {
+    // Optional hook for future metrics/logging.
+  });
+
+  healthMonitor.on('unhealthy', (details) => {
+    if (details?.failures === 1) {
+      console.warn('Stream health degraded:', details);
+    }
+  });
+
+  healthMonitor.start();
+})();
+
+process.on('SIGINT', () => {
+  shutdown(0).catch((error) => {
+    console.error('Shutdown failed', error);
+    process.exit(1);
+  });
+});
+
+process.on('SIGTERM', () => {
+  shutdown(0).catch((error) => {
+    console.error('Shutdown failed', error);
+    process.exit(1);
+  });
+});

--- a/src/services/StreamHealthMonitor.js
+++ b/src/services/StreamHealthMonitor.js
@@ -1,0 +1,394 @@
+const { EventEmitter } = require('events');
+const http = require('node:http');
+const prism = require('prism-media');
+
+class StreamHealthMonitor extends EventEmitter {
+  constructor({
+    config,
+    checkIntervalMs = 15000,
+    connectTimeoutMs = 5000,
+    playbackTimeoutMs = 8000,
+    minDecodedBytes,
+    failureThreshold = 2,
+    onUnhealthy,
+  }) {
+    super();
+
+    if (!config) {
+      throw new Error('StreamHealthMonitor requires a config object');
+    }
+
+    this.config = config;
+    this.checkIntervalMs = checkIntervalMs;
+    this.connectTimeoutMs = connectTimeoutMs;
+    this.playbackTimeoutMs = playbackTimeoutMs;
+    this.minDecodedBytes = Math.max(
+      config?.audio?.frameBytes || 0,
+      typeof minDecodedBytes === 'number' ? minDecodedBytes : (config?.audio?.frameBytes || 0) * 3,
+    );
+    this.failureThreshold = Math.max(1, failureThreshold);
+    this.onUnhealthy = typeof onUnhealthy === 'function' ? onUnhealthy : null;
+
+    this.timer = null;
+    this.currentCheck = null;
+    this.currentAbort = null;
+    this.consecutiveFailures = 0;
+    this.stopped = true;
+  }
+
+  start() {
+    if (!this.stopped) {
+      return;
+    }
+
+    this.stopped = false;
+    this.scheduleNextCheck(0);
+  }
+
+  async stop() {
+    if (this.stopped) {
+      return;
+    }
+
+    this.stopped = true;
+
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+
+    if (this.currentAbort) {
+      try {
+        this.currentAbort();
+      } catch (error) {
+        // Ignore abort errors
+      }
+    }
+
+    if (this.currentCheck) {
+      try {
+        await this.currentCheck;
+      } catch (error) {
+        // Ignore in-flight check errors when stopping
+      }
+    }
+
+    this.currentCheck = null;
+    this.currentAbort = null;
+    this.consecutiveFailures = 0;
+  }
+
+  scheduleNextCheck(delay) {
+    if (this.stopped) {
+      return;
+    }
+
+    if (this.timer) {
+      clearTimeout(this.timer);
+    }
+
+    this.timer = setTimeout(() => {
+      this.timer = null;
+      this.runCheck();
+    }, delay);
+
+    if (typeof this.timer.unref === 'function') {
+      this.timer.unref();
+    }
+  }
+
+  async runCheck() {
+    if (this.stopped || this.currentCheck) {
+      return;
+    }
+
+    this.currentCheck = this.performCheck();
+
+    let result;
+    try {
+      result = await this.currentCheck;
+    } catch (error) {
+      result = { ok: false, reason: 'Unexpected error during health check', error };
+    } finally {
+      this.currentCheck = null;
+      this.currentAbort = null;
+    }
+
+    if (!this.stopped) {
+      this.handleResult(result);
+      this.scheduleNextCheck(this.checkIntervalMs);
+    }
+  }
+
+  handleResult(result) {
+    if (result && result.skipped) {
+      return;
+    }
+
+    if (result && result.ok) {
+      if (this.consecutiveFailures > 0) {
+        console.log('Stream health recovered after', this.consecutiveFailures, 'failed check(s).');
+      }
+      this.consecutiveFailures = 0;
+      this.emit('healthy');
+      return;
+    }
+
+    this.consecutiveFailures += 1;
+
+    const reason = result?.reason || 'Unknown failure reason';
+    const error = result?.error;
+    console.warn(`Stream health check failed (${this.consecutiveFailures}/${this.failureThreshold}): ${reason}`);
+    if (error) {
+      console.warn('Health check error details:', error);
+    }
+
+    const failures = this.consecutiveFailures;
+    this.emit('unhealthy', { reason, error, failures });
+
+    if (failures >= this.failureThreshold) {
+      this.consecutiveFailures = 0;
+      if (this.onUnhealthy) {
+        try {
+          this.onUnhealthy({ reason, error, failures });
+        } catch (callbackError) {
+          console.error('Stream health monitor callback threw an error', callbackError);
+        }
+      }
+    }
+  }
+
+  performCheck() {
+    return new Promise((resolve) => {
+      let resolved = false;
+      let request = null;
+      let response = null;
+      let targetStream = null;
+      let playbackTimer = null;
+      let connectTimer = null;
+      let decoderCleanup = null;
+      let dataBytes = 0;
+
+      const cleanup = () => {
+        if (connectTimer) {
+          clearTimeout(connectTimer);
+          connectTimer = null;
+        }
+        if (playbackTimer) {
+          clearTimeout(playbackTimer);
+          playbackTimer = null;
+        }
+        if (targetStream) {
+          targetStream.removeListener('data', onData);
+          targetStream.removeListener('error', onStreamError);
+          targetStream.removeListener('end', onStreamEnd);
+        }
+        if (response) {
+          response.removeListener('error', onStreamError);
+          try {
+            response.destroy();
+          } catch (error) {
+            // Ignore destroy errors
+          }
+        }
+        if (decoderCleanup) {
+          try {
+            decoderCleanup();
+          } catch (error) {
+            // Ignore cleanup errors
+          }
+          decoderCleanup = null;
+        }
+        if (request) {
+          request.destroy();
+          request = null;
+        }
+        targetStream = null;
+        response = null;
+        this.currentAbort = null;
+      };
+
+      const finish = (result) => {
+        if (resolved) {
+          return;
+        }
+        resolved = true;
+        cleanup();
+        resolve(result);
+      };
+
+      const onStreamError = (error) => finish({ ok: false, reason: 'Stream error', error });
+      const onStreamEnd = () => finish({ ok: false, reason: 'Stream ended before enough data was received' });
+      const onData = (chunk) => {
+        if (!chunk || chunk.length === 0) {
+          return;
+        }
+        dataBytes += chunk.length;
+        if (dataBytes >= this.minDecodedBytes) {
+          finish({ ok: true });
+        }
+      };
+
+      const fail = (reason, error) => finish({ ok: false, reason, error });
+
+      const options = {
+        hostname: this.config?.healthCheck?.host || '127.0.0.1',
+        port: this.config.port,
+        path: this.config.streamEndpoint,
+        headers: {
+          'Cache-Control': 'no-cache',
+          'User-Agent': 'StreamHealthMonitor/1.0',
+        },
+      };
+
+      connectTimer = setTimeout(() => fail('Connection timed out'), this.connectTimeoutMs);
+      if (connectTimer && typeof connectTimer.unref === 'function') {
+        connectTimer.unref();
+      }
+
+      request = http.get(options, (res) => {
+        response = res;
+        if (connectTimer) {
+          clearTimeout(connectTimer);
+          connectTimer = null;
+        }
+
+        if (res.statusCode !== 200) {
+          res.resume();
+          fail(`Unexpected status code ${res.statusCode}`);
+          return;
+        }
+
+        playbackTimer = setTimeout(() => fail('Timed out waiting for stream data'), this.playbackTimeoutMs);
+
+        const pipeline = this.createPlaybackStream(res, fail);
+        decoderCleanup = pipeline.cleanup;
+        targetStream = pipeline.stream || res;
+
+        if (playbackTimer && typeof playbackTimer.unref === 'function') {
+          playbackTimer.unref();
+        }
+
+        targetStream.on('data', onData);
+        targetStream.on('error', onStreamError);
+        targetStream.on('end', onStreamEnd);
+        res.on('error', onStreamError);
+      });
+
+      request.on('error', (error) => fail('Request error', error));
+
+      this.currentAbort = () => {
+        finish({ ok: true, skipped: true });
+      };
+    });
+  }
+
+  createPlaybackStream(response, fail) {
+    const cleanupFns = [];
+
+    if (this.config.outputFormat === 'opus') {
+      const demuxer = new prism.opus.OggDemuxer();
+      const decoder = new prism.opus.Decoder({
+        frameSize: this.config.audio.frameSamples,
+        channels: this.config.audio.channels,
+        rate: this.config.audio.sampleRate,
+      });
+
+      const onDemuxerError = (error) => fail('Ogg demuxer error', error);
+      const onDecoderError = (error) => fail('Opus decoder error', error);
+
+      demuxer.on('error', onDemuxerError);
+      decoder.on('error', onDecoderError);
+
+      cleanupFns.push(() => {
+        demuxer.removeListener('error', onDemuxerError);
+        decoder.removeListener('error', onDecoderError);
+        try {
+          response.unpipe(demuxer);
+        } catch (error) {
+          // Ignore unpipe errors
+        }
+        try {
+          demuxer.unpipe(decoder);
+        } catch (error) {
+          // Ignore unpipe errors
+        }
+        demuxer.destroy();
+        decoder.destroy();
+      });
+
+      response.pipe(demuxer).pipe(decoder);
+
+      return {
+        stream: decoder,
+        cleanup: () => {
+          while (cleanupFns.length) {
+            const fn = cleanupFns.pop();
+            try {
+              fn();
+            } catch (error) {
+              // Ignore cleanup errors
+            }
+          }
+        },
+      };
+    }
+
+    if (this.config.outputFormat === 'mp3') {
+      const ffmpeg = new prism.FFmpeg({
+        args: [
+          '-analyzeduration',
+          '0',
+          '-loglevel',
+          '0',
+          '-f',
+          'mp3',
+          '-i',
+          'pipe:0',
+          '-f',
+          's16le',
+          '-ar',
+          String(this.config.audio.sampleRate),
+          '-ac',
+          String(this.config.audio.channels),
+        ],
+      });
+
+      const onFfmpegError = (error) => fail('FFmpeg decode error', error);
+      ffmpeg.on('error', onFfmpegError);
+
+      cleanupFns.push(() => {
+        ffmpeg.removeListener('error', onFfmpegError);
+        try {
+          response.unpipe(ffmpeg);
+        } catch (error) {
+          // Ignore unpipe errors
+        }
+        ffmpeg.destroy();
+      });
+
+      response.pipe(ffmpeg);
+
+      return {
+        stream: ffmpeg,
+        cleanup: () => {
+          while (cleanupFns.length) {
+            const fn = cleanupFns.pop();
+            try {
+              fn();
+            } catch (error) {
+              // Ignore cleanup errors
+            }
+          }
+        },
+      };
+    }
+
+    return {
+      stream: response,
+      cleanup: () => {},
+    };
+  }
+}
+
+module.exports = StreamHealthMonitor;


### PR DESCRIPTION
## Summary
- add health check configuration options for the stream monitor
- refactor the application bootstrap to support restartable runtime management and hook in the health monitor
- implement a StreamHealthMonitor that pulls and decodes the stream to verify audio playback before triggering automatic restarts

## Testing
- node -e "require('./src/services/StreamHealthMonitor'); console.log('StreamHealthMonitor loaded');"

------
https://chatgpt.com/codex/tasks/task_e_68d516de73ac8324a07b4fd191fafd37