### PR TITLE
Réduit le badge En direct

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -693,12 +693,12 @@
                   </button>
                   <div class="space-y-3">
                     <div class="flex flex-wrap items-center gap-3">
-                      <span class="inline-flex items-center gap-2 rounded-full border border-emerald-400/40 bg-emerald-400/15 px-3 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-emerald-200">
-                        <span class="relative flex h-2 w-2">
-                          <span class="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-200 opacity-75"></span>
-                          <span class="relative inline-flex h-2 w-2 rounded-full bg-emerald-700"></span>
+                      <span class="inline-flex items-center gap-1.5 rounded-full border border-emerald-400/30 bg-emerald-400/10 px-2 py-0.5 text-[0.6rem] font-semibold uppercase tracking-[0.25em] text-emerald-100">
+                        <span class="relative flex h-1.5 w-1.5">
+                          <span class="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-100 opacity-75"></span>
+                          <span class="relative inline-flex h-1.5 w-1.5 rounded-full bg-emerald-600"></span>
                         </span>
-                        <${Activity} class="h-3.5 w-3.5" aria-hidden="true" />
+                        <${Activity} class="h-3 w-3" aria-hidden="true" />
                         <span>En direct</span>
                       </span>
                       ${(() => {


### PR DESCRIPTION
## Summary
- réduit la taille et la visibilité du badge "En direct" dans la carte de flux audio
- ajuste les dimensions de l'icône et de l'animation de pulsation pour rester cohérentes

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d56aaa03d08324b700db5b458a9eee