### PR TITLE
Update site metadata to use libre-antenne.xyz domain

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -20,8 +20,8 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="application-name" content="Libre Antenne" />
     <meta name="apple-mobile-web-app-title" content="Libre Antenne" />
-    <link rel="canonical" href="https://libre-antenne.audio/" />
-    <link rel="alternate" href="https://libre-antenne.audio/" hreflang="fr-FR" />
+    <link rel="canonical" href="https://libre-antenne.xyz/" />
+    <link rel="alternate" href="https://libre-antenne.xyz/" hreflang="fr-FR" />
     <link rel="manifest" href="/site.webmanifest" />
     <link rel="icon" type="image/svg+xml" href="/icons/icon-192.svg" />
     <link rel="apple-touch-icon" sizes="192x192" href="/icons/icon-192.svg" />
@@ -43,14 +43,14 @@
     </noscript>
     <meta property="og:type" content="website" />
     <meta property="og:locale" content="fr_FR" />
-    <meta property="og:url" content="https://libre-antenne.audio/" />
+    <meta property="og:url" content="https://libre-antenne.xyz/" />
     <meta property="og:site_name" content="Libre Antenne" />
     <meta property="og:title" content="Libre Antenne · Radio libre et streaming communautaire" />
     <meta
       property="og:description"
       content="Libre Antenne diffuse en continu les voix du salon Discord : un espace sans filtre pour les esprits libres, les joueurs et les noctambules."
     />
-    <meta property="og:image" content="https://libre-antenne.audio/icons/icon-512.png" />
+    <meta property="og:image" content="https://libre-antenne.xyz/icons/icon-512.png" />
     <meta property="og:image:alt" content="Illustration du direct communautaire Libre Antenne" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@libreantenne" />
@@ -60,7 +60,7 @@
       name="twitter:description"
       content="Rejoins le flux audio Libre Antenne pour partager ta voix en direct et écouter la communauté."
     />
-    <meta name="twitter:image" content="https://libre-antenne.audio/icons/icon-512.png" />
+    <meta name="twitter:image" content="https://libre-antenne.xyz/icons/icon-512.png" />
     <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio" defer></script>
     <script type="application/ld+json">
       {
@@ -68,13 +68,13 @@
         "@type": "BroadcastService",
         "name": "Libre Antenne",
         "description": "Flux audio communautaire en direct diffusé depuis Discord, libre d'accès et sans filtre.",
-        "url": "https://libre-antenne.audio/",
+        "url": "https://libre-antenne.xyz/",
         "areaServed": "FR",
         "inLanguage": "fr-FR",
         "provider": {
           "@type": "Organization",
           "name": "Libre Antenne",
-          "url": "https://libre-antenne.audio/"
+          "url": "https://libre-antenne.xyz/"
         },
         "broadcastDisplayName": "Libre Antenne – Direct Discord",
         "broadcastFrequency": "Streaming en ligne",


### PR DESCRIPTION
## Summary
- update the canonical, Open Graph, Twitter and JSON-LD URLs to libre-antenne.xyz

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6b7a9108c832497e4c1adae13aaa7