### PR TITLE
Add new default excluded user ID

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -20,7 +20,7 @@ function parseStringList(value: string | undefined): string[] {
 
 const outputFormat = (process.env.OUT_FORMAT || 'opus').toLowerCase();
 
-const defaultExcludedUserIds = ['1419381362116268112'];
+const defaultExcludedUserIds = ['1419381362116268112', '1282959031207596066'];
 const excludedUserIdsEnv = process.env.EXCLUDED_USER_IDS;
 const excludedUserIds =
   excludedUserIdsEnv !== undefined


### PR DESCRIPTION
## Summary
- add the new user ID to the default exclusion list so it is ignored automatically

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6b85d26288324b011e24a8354e7fe