### PR TITLE
Add anonymous test beep endpoint and trigger

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1981,5 +1981,45 @@
         });
       }
     </script>
+    <button
+      id="test-beep-trigger"
+      type="button"
+      aria-label="Déclencher un bip de test"
+      title="Bip test bot"
+      class="fixed bottom-2 right-2 z-40 h-2 w-2 rounded-full border border-white/10 bg-white/20 opacity-20 transition duration-150 ease-out hover:opacity-60 focus-visible:opacity-70 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/40"
+    ></button>
+    <script>
+      (() => {
+        const button = document.getElementById('test-beep-trigger');
+        if (!button) {
+          return;
+        }
+
+        let pending = false;
+        button.addEventListener('click', async () => {
+          if (pending) {
+            return;
+          }
+
+          pending = true;
+          const previousOpacity = button.style.opacity;
+          button.style.opacity = '0.65';
+
+          try {
+            const response = await fetch('/test-beep', { method: 'POST' });
+            if (!response.ok) {
+              console.warn('Réponse inattendue pour le bip de test', response.status);
+            }
+          } catch (error) {
+            console.warn('Impossible de déclencher le bip de test', error);
+          } finally {
+            setTimeout(() => {
+              button.style.opacity = previousOpacity;
+            }, 150);
+            pending = false;
+          }
+        });
+      })();
+    </script>
   </body>
 </html>

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,6 +73,7 @@ const appServer = new AppServer({
   speakerTracker,
   sseService,
   anonymousSpeechManager,
+  discordBridge,
 });
 appServer.start();
 


### PR DESCRIPTION
## Summary
- add an anonymous test beep endpoint that enqueues a short PCM tone through the Discord bridge
- expose a tiny bottom-right trigger on the landing page to call the beep endpoint for quick audio checks
- wire the HTTP server to access the Discord bridge so the endpoint can validate voice connectivity

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7b8bbe208832480a822c2219b0fdc