### PR TITLE
Agrandir le bouton de test du bip

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1986,7 +1986,7 @@
       type="button"
       aria-label="Déclencher un bip de test"
       title="Bip test bot"
-      class="fixed bottom-2 right-2 z-40 h-2 w-2 rounded-full border border-white/10 bg-white/20 opacity-20 transition duration-150 ease-out hover:opacity-60 focus-visible:opacity-70 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/40"
+      class="fixed bottom-2 right-2 z-40 h-12 w-12 rounded-full border border-white/10 bg-white/20 opacity-20 transition duration-150 ease-out hover:opacity-60 focus-visible:opacity-70 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/40"
     ></button>
     <script>
       (() => {


### PR DESCRIPTION
## Summary
- agrandit le bouton fixe utilisé pour déclencher le bip de test afin de le rendre plus visible et accessible

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d7d02a108483249c57e2898d6a5e91