### PR TITLE
Add boutique storefront with Stripe and CoinGate checkout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "ffmpeg-static": "^5.2.0",
         "opusscript": "^0.0.8",
         "prism-media": "^1.3.5",
+        "stripe": "^16.12.0",
         "winston": "^3.17.0",
         "ws": "^8.18.2"
       },
@@ -2174,6 +2175,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/stripe": {
+      "version": "16.12.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-16.12.0.tgz",
+      "integrity": "sha512-H7eFVLDxeTNNSn4JTRfL2//LzCbDrMSZ+2q1c7CanVWgK2qIW5TwS+0V7N9KcKZZNpYh/uCqK0PyZh/2UsaAtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=8.1.0",
+        "qs": "^6.11.0"
+      },
+      "engines": {
+        "node": ">=12.*"
       }
     },
     "node_modules/tar": {

--- a/package.json
+++ b/package.json
@@ -32,13 +32,14 @@
     "ffmpeg-static": "^5.2.0",
     "opusscript": "^0.0.8",
     "prism-media": "^1.3.5",
+    "stripe": "^16.12.0",
     "winston": "^3.17.0",
     "ws": "^8.18.2"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
     "@types/node": "^22.10.1",
-    "typescript": "^5.6.3",
-    "ts-node": "^10.9.2"
+    "ts-node": "^10.9.2",
+    "typescript": "^5.6.3"
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -201,8 +201,12 @@
       import {
         Activity,
         AlertCircle,
+        BadgeCheck,
         ArrowRight,
         Clock3,
+        Coffee,
+        Coins,
+        CreditCard,
         Headphones,
         Menu,
         Mic,
@@ -212,6 +216,10 @@
         Play,
         RefreshCcw,
         ShieldCheck,
+        ShoppingBag,
+        Shirt,
+        Sparkles,
+        Truck,
         Users,
         Video,
         Volume,
@@ -1377,15 +1385,392 @@
         `;
       };
 
+      const PAYMENT_PROVIDERS = {
+        stripe: {
+          label: 'Stripe',
+          helper: 'Cartes bancaires, Apple Pay et Google Pay.',
+          accent:
+            'border-indigo-400/50 bg-indigo-500/20 hover:bg-indigo-500/30 focus:ring-indigo-300',
+          Icon: CreditCard,
+        },
+        coingate: {
+          label: 'CoinGate',
+          helper: 'Crypto, Lightning Network et virements SEPA.',
+          accent:
+            'border-emerald-400/50 bg-emerald-500/20 hover:bg-emerald-500/30 focus:ring-emerald-300',
+          Icon: Coins,
+        },
+      };
+
+      const FEEDBACK_STYLES = {
+        success: 'border-emerald-400/40 bg-emerald-500/10 text-emerald-100',
+        info: 'border-sky-400/40 bg-sky-500/10 text-sky-100',
+        error: 'border-rose-400/40 bg-rose-500/10 text-rose-100',
+      };
+
+      const parseCheckoutFeedback = () => {
+        if (typeof window === 'undefined') {
+          return null;
+        }
+
+        try {
+          const hash = window.location.hash || '';
+          const [path = '', query = ''] = hash.split('?');
+          if (!path.toLowerCase().includes('boutique')) {
+            return null;
+          }
+
+          const params = new URLSearchParams(query);
+          const status = (params.get('checkout') || '').toLowerCase();
+          if (!status) {
+            return null;
+          }
+
+          let type = 'info';
+          let message = '';
+          if (status === 'success') {
+            type = 'success';
+            message = 'Merci pour ton soutien ! La commande est bien prise en compte.';
+          } else if (status === 'cancelled') {
+            type = 'info';
+            message = 'Paiement annulé. Tu peux réessayer quand tu veux.';
+          } else {
+            type = 'error';
+            message = 'Une erreur est survenue lors du paiement. Aucun débit n’a été effectué.';
+          }
+
+          if (typeof window.history?.replaceState === 'function') {
+            window.history.replaceState(null, '', '#/boutique');
+          }
+
+          return { type, message };
+        } catch (error) {
+          console.warn('Impossible de lire le statut de paiement', error);
+          return null;
+        }
+      };
+
+      const ShopProductCard = ({ product, checkoutState, onCheckout }) => {
+        const providerSections = (product.providers || [])
+          .map((provider) => {
+            const details = PAYMENT_PROVIDERS[provider];
+            if (!details) {
+              return null;
+            }
+            const isPending =
+              checkoutState.pending &&
+              checkoutState.productId === product.id &&
+              checkoutState.provider === provider;
+            const ButtonIcon = details.Icon;
+            return html`
+              <div key=${`${product.id}-${provider}`} class="flex flex-col gap-1">
+                <button
+                  type="button"
+                  class=${`flex w-full items-center justify-center gap-2 rounded-full border px-4 py-2 text-sm font-semibold text-white transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-slate-950 disabled:cursor-not-allowed disabled:opacity-50 ${details.accent}`}
+                  onClick=${() => onCheckout(product.id, provider)}
+                  disabled=${isPending}
+                >
+                  ${isPending ? 'Redirection…' : `Payer avec ${details.label}`}
+                  <${ButtonIcon} class="h-4 w-4" aria-hidden="true" />
+                </button>
+                <span class="text-xs text-slate-400">${details.helper}</span>
+              </div>
+            `;
+          })
+          .filter(Boolean);
+
+        return html`
+          <article class="flex h-full flex-col rounded-3xl border border-white/10 bg-white/5 p-6 shadow-lg shadow-slate-950/40 backdrop-blur">
+            <div class="flex items-center justify-between">
+              <span class="text-4xl" aria-hidden="true">${product.emoji || '🛒'}</span>
+              ${product.highlight
+                ? html`<span class="inline-flex items-center gap-1 rounded-full border border-fuchsia-400/40 bg-fuchsia-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.25em] text-fuchsia-100">
+                    <${Sparkles} class="h-3 w-3" aria-hidden="true" />
+                    <span class="tracking-normal">Coup de cœur</span>
+                  </span>`
+                : null}
+            </div>
+            ${Array.isArray(product.badges) && product.badges.length > 0
+              ? html`<div class="mt-4 flex flex-wrap gap-2">
+                  ${product.badges.map((badge, index) =>
+                    html`<span
+                      key=${`${product.id}-badge-${index}`}
+                      class="inline-flex items-center gap-1 rounded-full border border-white/10 bg-black/30 px-3 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.35em] text-slate-200/90"
+                    >
+                      <${BadgeCheck} class="h-3 w-3 text-emerald-300" aria-hidden="true" />
+                      <span class="tracking-normal">${badge}</span>
+                    </span>`
+                  )}
+                </div>`
+              : null}
+            <h3 class="mt-5 text-xl font-semibold text-white">${product.name}</h3>
+            <p class="mt-2 text-sm leading-relaxed text-slate-300">${product.description}</p>
+            <div class=${`mt-4 rounded-3xl border border-white/10 px-5 py-4 ${product.accentSoft || 'bg-white/10'}`}>
+              <p class="text-3xl font-bold text-white">${product.price?.formatted || '—'}</p>
+              <p class="text-xs uppercase tracking-[0.35em] text-slate-300">TTC</p>
+            </div>
+            <ul class="mt-5 space-y-2 text-sm text-slate-200">
+              ${(product.includes || []).map((item, index) =>
+                html`<li key=${`${product.id}-feature-${index}`} class="flex items-start gap-2">
+                  <${ShieldCheck} class="mt-0.5 h-4 w-4 text-indigo-300" aria-hidden="true" />
+                  <span>${item}</span>
+                </li>`
+              )}
+            </ul>
+            <p class="mt-4 flex items-center gap-2 text-xs text-slate-400">
+              <${Truck} class="h-4 w-4" aria-hidden="true" />
+              ${product.shippingEstimate || 'Livraison estimée communiquée après commande'}
+            </p>
+            <div class="mt-6 flex flex-col gap-3">
+              ${providerSections.length > 0
+                ? providerSections
+                : html`<div class="rounded-2xl border border-white/10 bg-black/40 px-4 py-3 text-center text-sm text-slate-300">
+                    Paiements bientôt disponibles pour ce produit.
+                  </div>`}
+            </div>
+            ${checkoutState.error && checkoutState.productId === product.id
+              ? html`<p class="mt-4 rounded-xl border border-rose-400/30 bg-rose-500/10 px-4 py-3 text-xs text-rose-100">
+                  ${checkoutState.error}
+                </p>`
+              : null}
+          </article>
+        `;
+      };
+
+      const ShopPage = () => {
+        const [loading, setLoading] = useState(true);
+        const [products, setProducts] = useState([]);
+        const [error, setError] = useState('');
+        const [checkoutState, setCheckoutState] = useState({
+          productId: null,
+          provider: null,
+          pending: false,
+          error: '',
+        });
+        const [feedback, setFeedback] = useState(parseCheckoutFeedback);
+
+        const fetchProducts = useCallback(async () => {
+          setLoading(true);
+          try {
+            const response = await fetch('/api/shop/products');
+            if (!response.ok) {
+              throw new Error('Réponse inattendue du serveur.');
+            }
+            const payload = await response.json();
+            const list = Array.isArray(payload?.products) ? payload.products : [];
+            setProducts(list);
+            setError('');
+          } catch (err) {
+            console.warn('Impossible de charger la boutique', err);
+            setError('Boutique momentanément indisponible. Réessaie dans quelques minutes.');
+          } finally {
+            setLoading(false);
+          }
+        }, []);
+
+        useEffect(() => {
+          fetchProducts();
+        }, [fetchProducts]);
+
+        useEffect(() => {
+          if (!feedback) {
+            return undefined;
+          }
+          const timer = setTimeout(() => setFeedback(null), 6000);
+          return () => clearTimeout(timer);
+        }, [feedback]);
+
+        const getReturnUrls = useCallback(() => {
+          if (typeof window === 'undefined') {
+            return { success: '', cancel: '' };
+          }
+          const base = `${window.location.origin}${window.location.pathname}${window.location.search}`;
+          return {
+            success: `${base}#/boutique?checkout=success`,
+            cancel: `${base}#/boutique?checkout=cancelled`,
+          };
+        }, []);
+
+        const handleCheckout = useCallback(
+          async (productId, provider) => {
+            setCheckoutState({ productId, provider, pending: true, error: '' });
+            setFeedback(null);
+
+            try {
+              const { success, cancel } = getReturnUrls();
+              const response = await fetch('/api/shop/checkout', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                  productId,
+                  provider,
+                  successUrl: success || undefined,
+                  cancelUrl: cancel || undefined,
+                }),
+              });
+
+              if (!response.ok) {
+                let message = 'Impossible de lancer le paiement.';
+                try {
+                  const data = await response.json();
+                  if (data?.message) {
+                    message = data.message;
+                  }
+                } catch (parseError) {
+                  console.warn('Impossible de lire la réponse de paiement', parseError);
+                }
+                throw new Error(message);
+              }
+
+              const payload = await response.json();
+              if (payload?.url) {
+                window.location.href = payload.url;
+                return;
+              }
+
+              throw new Error('Lien de paiement introuvable.');
+            } catch (err) {
+              const message =
+                err instanceof Error ? err.message : 'Impossible de lancer le paiement.';
+              setCheckoutState({ productId, provider, pending: false, error: message });
+              setFeedback({ type: 'error', message });
+            }
+          },
+          [getReturnUrls],
+        );
+
+        const sortedProducts = useMemo(() => {
+          return products
+            .slice()
+            .sort((a, b) => Number(Boolean(b.highlight)) - Number(Boolean(a.highlight)));
+        }, [products]);
+
+        return html`
+          <${Fragment}>
+            <section class="space-y-6 rounded-3xl border border-white/10 bg-white/5 px-8 py-12 shadow-xl shadow-slate-950/40 backdrop-blur-xl">
+              <p class="text-xs uppercase tracking-[0.35em] text-slate-300">Boutique officielle</p>
+              <div class="grid gap-8 lg:grid-cols-[1.1fr_1fr] lg:items-center">
+                <div class="space-y-4">
+                  <h1 class="text-4xl font-bold tracking-tight text-white sm:text-5xl">
+                    La Boutique Libre Antenne
+                  </h1>
+                  <p class="text-base leading-relaxed text-slate-200">
+                    Soutiens la libre antenne et repars avec des pièces conçues pour les noctambules,
+                    les gamers et les voix libres. Paiement sécurisé via Stripe ou CoinGate.
+                  </p>
+                  <div class="flex flex-wrap gap-3 text-xs text-slate-200">
+                    <span class="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/10 px-4 py-1.5">
+                      <${ShoppingBag} class="h-4 w-4" aria-hidden="true" />
+                      Stripe & CoinGate
+                    </span>
+                    <span class="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/10 px-4 py-1.5">
+                      <${Truck} class="h-4 w-4" aria-hidden="true" />
+                      Livraison France & Europe
+                    </span>
+                    <span class="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/10 px-4 py-1.5">
+                      <${Coffee} class="h-4 w-4" aria-hidden="true" />
+                      Production à la demande
+                    </span>
+                  </div>
+                </div>
+                <div class="rounded-3xl border border-fuchsia-400/40 bg-fuchsia-500/10 px-6 py-6 text-sm text-fuchsia-100 shadow-lg shadow-fuchsia-900/30">
+                  <p class="text-xs uppercase tracking-[0.35em] text-fuchsia-200/80">Libre antenne</p>
+                  <p class="mt-3 leading-relaxed">
+                    Chaque achat finance l’hébergement du bot, le mixage audio et la préparation de
+                    nouvelles émissions en roue libre. Merci de faire tourner la radio indépendante.
+                  </p>
+                </div>
+              </div>
+            </section>
+
+            ${feedback
+              ? (() => {
+                  const style = FEEDBACK_STYLES[feedback.type] || FEEDBACK_STYLES.info;
+                  const Icon =
+                    feedback.type === 'success'
+                      ? ShieldCheck
+                      : feedback.type === 'error'
+                      ? AlertCircle
+                      : RefreshCcw;
+                  return html`<div class=${`rounded-2xl border px-5 py-4 text-sm shadow-lg shadow-slate-950/40 backdrop-blur ${style}`}>
+                    <div class="flex items-center gap-3">
+                      <${Icon} class="h-4 w-4" aria-hidden="true" />
+                      <span>${feedback.message}</span>
+                    </div>
+                  </div>`;
+                })()
+              : null}
+
+            <section class="space-y-6">
+              ${loading
+                ? html`<div class="rounded-3xl border border-white/10 bg-black/30 px-6 py-10 text-center text-sm text-slate-300">
+                    <span class="mr-3 inline-block h-4 w-4 animate-spin rounded-full border-2 border-slate-300 border-t-transparent"></span>
+                    Chargement de la boutique…
+                  </div>`
+                : error
+                ? html`<div class="rounded-3xl border border-rose-400/40 bg-rose-500/10 px-6 py-6 text-sm text-rose-100 shadow-lg shadow-rose-900/40">
+                    <p>${error}</p>
+                    <button
+                      type="button"
+                      class="mt-4 inline-flex items-center gap-2 rounded-full border border-white/30 bg-white/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-white transition hover:bg-white/20"
+                      onClick=${fetchProducts}
+                    >
+                      Réessayer
+                      <${RefreshCcw} class="h-3.5 w-3.5" aria-hidden="true" />
+                    </button>
+                  </div>`
+                : html`<div class="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+                    ${sortedProducts.map((product) =>
+                      html`<${ShopProductCard}
+                        key=${product.id}
+                        product=${product}
+                        checkoutState=${checkoutState}
+                        onCheckout=${handleCheckout}
+                      />`
+                    )}
+                  </div>`}
+            </section>
+
+            <section class="grid gap-6 lg:grid-cols-2">
+              <div class="rounded-3xl border border-white/10 bg-slate-950/60 p-6 shadow-lg shadow-slate-950/40 backdrop-blur">
+                <h3 class="flex items-center gap-2 text-lg font-semibold text-white">
+                  <${ShieldCheck} class="h-5 w-5 text-emerald-300" aria-hidden="true" />
+                  Paiements vérifiés
+                </h3>
+                <p class="mt-3 text-sm leading-relaxed text-slate-300">
+                  Stripe chiffre chaque transaction et accepte la plupart des cartes, Apple Pay et
+                  Google Pay. Aucun numéro sensible n’est stocké sur nos serveurs.
+                </p>
+              </div>
+              <div class="rounded-3xl border border-white/10 bg-slate-950/60 p-6 shadow-lg shadow-slate-950/40 backdrop-blur">
+                <h3 class="flex items-center gap-2 text-lg font-semibold text-white">
+                  <${Coins} class="h-5 w-5 text-emerald-300" aria-hidden="true" />
+                  Crypto friendly
+                </h3>
+                <p class="mt-3 text-sm leading-relaxed text-slate-300">
+                  CoinGate permet de régler en Bitcoin, Lightning Network et plus de 70 altcoins, avec
+                  conversion instantanée en euros ou conservation en crypto.
+                </p>
+              </div>
+            </section>
+          </${Fragment}>
+        `;
+      };
+
       const NAV_LINKS = [
         { label: 'Accueil', route: 'home', hash: '#/' },
+        { label: 'Boutique', route: 'shop', hash: '#/boutique' },
         { label: 'À propos', route: 'about', hash: '#/about' },
       ];
 
       const getRouteFromHash = () => {
         const hash = window.location.hash.replace(/^#/, '').toLowerCase();
-        if (hash === '/about' || hash === 'about') {
+        const [path] = hash.split('?');
+        if (path === '/about' || path === 'about') {
           return 'about';
+        }
+        if (path === '/boutique' || path === 'boutique') {
+          return 'shop';
         }
         return 'home';
       };
@@ -2247,9 +2632,12 @@
 
         const handleNavigate = (event, targetRoute) => {
           event.preventDefault();
-          const targetHash = targetRoute === 'home' ? '#/' : '#/about';
-          if (window.location.hash !== targetHash) {
-            window.location.hash = targetHash;
+          const link = NAV_LINKS.find((entry) => entry.route === targetRoute);
+          if (!link) {
+            return;
+          }
+          if (window.location.hash !== link.hash) {
+            window.location.hash = link.hash;
           } else {
             setRoute(targetRoute);
           }
@@ -2378,6 +2766,8 @@
                   ${
                     route === 'about'
                       ? html`<${AboutPage} />`
+                      : route === 'shop'
+                      ? html`<${ShopPage} />`
                       : html`<${HomePage}
                           status=${status}
                           lastUpdateLabel=${lastUpdateLabel}

--- a/src/config.ts
+++ b/src/config.ts
@@ -35,6 +35,24 @@ export interface AudioConfig {
   frameBytes: number;
 }
 
+export interface ShopStripeConfig {
+  secretKey?: string;
+  priceIds: Record<string, string>;
+}
+
+export interface ShopCoingateConfig {
+  apiKey?: string;
+  environment: 'sandbox' | 'live';
+  callbackUrl?: string;
+}
+
+export interface ShopConfig {
+  currency: string;
+  locale: string;
+  stripe: ShopStripeConfig;
+  coingate: ShopCoingateConfig;
+}
+
 export interface Config {
   botToken: string;
   guildId?: string;
@@ -51,6 +69,7 @@ export interface Config {
   audio: AudioConfig;
   mimeTypes: Record<string, string>;
   excludedUserIds: string[];
+  shop: ShopConfig;
 }
 
 const config: Config = {
@@ -78,6 +97,28 @@ const config: Config = {
     mp3: 'audio/mpeg',
   },
   excludedUserIds,
+  shop: {
+    currency: 'eur',
+    locale: 'fr-FR',
+    stripe: {
+      secretKey: process.env.SHOP_STRIPE_SECRET_KEY || undefined,
+      priceIds: Object.entries({
+        mug: process.env.SHOP_STRIPE_PRICE_MUG,
+        tshirt: process.env.SHOP_STRIPE_PRICE_TSHIRT,
+        pack: process.env.SHOP_STRIPE_PRICE_PACK,
+      }).reduce<Record<string, string>>((acc, [key, value]) => {
+        if (value) {
+          acc[key] = value;
+        }
+        return acc;
+      }, {}),
+    },
+    coingate: {
+      apiKey: process.env.SHOP_COINGATE_API_KEY || undefined,
+      environment: process.env.SHOP_COINGATE_ENVIRONMENT === 'live' ? 'live' : 'sandbox',
+      callbackUrl: process.env.SHOP_COINGATE_CALLBACK_URL || undefined,
+    },
+  },
 };
 
 config.audio.frameSamples = Math.floor(

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import SseService from './services/SseService';
 import SpeakerTracker from './services/SpeakerTracker';
 import DiscordAudioBridge from './discord/DiscordAudioBridge';
 import AnonymousSpeechManager from './services/AnonymousSpeechManager';
+import ShopService from './services/ShopService';
 
 const mixer = new AudioMixer({
   frameBytes: config.audio.frameBytes,
@@ -67,6 +68,8 @@ const anonymousSpeechManager = new AnonymousSpeechManager({
   sseService,
 });
 
+const shopService = new ShopService({ config });
+
 const appServer = new AppServer({
   config,
   transcoder,
@@ -74,6 +77,7 @@ const appServer = new AppServer({
   sseService,
   anonymousSpeechManager,
   discordBridge,
+  shopService,
 });
 appServer.start();
 

--- a/src/services/ShopService.ts
+++ b/src/services/ShopService.ts
@@ -1,0 +1,401 @@
+import Stripe from 'stripe';
+import type { Config } from '../config';
+
+export type ShopProvider = 'stripe' | 'coingate';
+
+interface ProductDefinition {
+  id: string;
+  name: string;
+  description: string;
+  priceCents: number;
+  currency: string;
+  includes: string[];
+  shippingEstimate: string;
+  badges: string[];
+  accent: string;
+  accentSoft: string;
+  emoji: string;
+  highlight?: boolean;
+  stripePriceKey?: string;
+}
+
+interface InternalProduct extends ProductDefinition {
+  stripePriceId?: string;
+}
+
+export interface PublicProduct {
+  id: string;
+  name: string;
+  description: string;
+  price: {
+    amount: number;
+    currency: string;
+    formatted: string;
+  };
+  includes: string[];
+  shippingEstimate: string;
+  badges: string[];
+  accent: string;
+  accentSoft: string;
+  emoji: string;
+  highlight: boolean;
+  providers: ShopProvider[];
+}
+
+export interface CheckoutRequestOptions {
+  productId: string;
+  provider: ShopProvider;
+  successUrl?: string;
+  cancelUrl?: string;
+  customerEmail?: string;
+}
+
+export interface CheckoutSession {
+  provider: ShopProvider;
+  url: string;
+}
+
+export class ShopError extends Error {
+  public readonly code: string;
+
+  public readonly status: number;
+
+  constructor(code: string, message: string, status = 400) {
+    super(message);
+    this.name = 'ShopError';
+    this.code = code;
+    this.status = status;
+  }
+}
+
+interface ShopServiceOptions {
+  config: Config;
+}
+
+export default class ShopService {
+  private readonly config: Config;
+
+  private readonly products: InternalProduct[];
+
+  private readonly stripe: Stripe | null;
+
+  private readonly coingateApiBase: string | null;
+
+  constructor({ config }: ShopServiceOptions) {
+    this.config = config;
+    this.products = this.initializeProducts();
+    this.stripe = this.initializeStripe();
+    this.coingateApiBase = this.initializeCoingateBaseUrl();
+  }
+
+  public getCurrency(): string {
+    return this.config.shop.currency;
+  }
+
+  public getProducts(): PublicProduct[] {
+    return this.products.map((product) => ({
+      id: product.id,
+      name: product.name,
+      description: product.description,
+      price: {
+        amount: product.priceCents / 100,
+        currency: product.currency,
+        formatted: this.formatPrice(product.priceCents, product.currency),
+      },
+      includes: product.includes,
+      shippingEstimate: product.shippingEstimate,
+      badges: product.badges,
+      accent: product.accent,
+      accentSoft: product.accentSoft,
+      emoji: product.emoji,
+      highlight: Boolean(product.highlight),
+      providers: this.computeAvailableProviders(product),
+    }));
+  }
+
+  public async createCheckoutSession(options: CheckoutRequestOptions): Promise<CheckoutSession> {
+    const product = this.products.find((entry) => entry.id === options.productId);
+    if (!product) {
+      throw new ShopError('PRODUCT_NOT_FOUND', "Produit introuvable.", 404);
+    }
+
+    switch (options.provider) {
+      case 'stripe':
+        return this.createStripeCheckout(product, options);
+      case 'coingate':
+        return this.createCoingateCheckout(product, options);
+      default:
+        throw new ShopError('PROVIDER_UNSUPPORTED', 'Fournisseur de paiement non pris en charge.', 400);
+    }
+  }
+
+  private initializeProducts(): InternalProduct[] {
+    const { shop } = this.config;
+    const definitions: ProductDefinition[] = [
+      {
+        id: 'mug-classique',
+        name: 'Mug Libre Antenne',
+        description: 'Mug céramique 330 ml pour affronter les libres antennes nocturnes avec style.',
+        priceCents: 1800,
+        currency: shop.currency,
+        includes: [
+          'Impression double face résistante au lave-vaisselle',
+          'Capacité 330 ml pour les longues nuits en direct',
+          'Packaging protecteur anti-chocs',
+        ],
+        shippingEstimate: 'Production & expédition sous 5 à 7 jours ouvrés',
+        badges: ['Edition nocturne'],
+        accent: 'from-indigo-500/20 via-fuchsia-500/20 to-purple-500/20',
+        accentSoft: 'bg-indigo-500/10',
+        emoji: '☕️',
+        stripePriceKey: 'mug',
+      },
+      {
+        id: 'tshirt-logo',
+        name: 'T-shirt Signal Brut',
+        description: 'T-shirt coupe unisexe 100 % coton bio avec logo Libre Antenne sérigraphié.',
+        priceCents: 3200,
+        currency: shop.currency,
+        includes: [
+          'Coton peigné 180 g/m² certifié OEKO-TEX®',
+          'Impression douce durable haute densité',
+          'Tailles du XS au XXL (guide fourni après commande)',
+        ],
+        shippingEstimate: 'Impression à la demande · 7 à 10 jours ouvrés',
+        badges: ['Best-seller'],
+        accent: 'from-sky-500/20 via-indigo-500/20 to-blue-500/20',
+        accentSoft: 'bg-sky-500/10',
+        emoji: '👕',
+        highlight: true,
+        stripePriceKey: 'tshirt',
+      },
+      {
+        id: 'pack-essentiel',
+        name: 'Pack Essentiel',
+        description: 'Le duo mug + t-shirt pour afficher ta vibe Libre Antenne partout.',
+        priceCents: 4500,
+        currency: shop.currency,
+        includes: [
+          'Mug Libre Antenne',
+          'T-shirt Signal Brut',
+          'Autocollants holographiques exclusifs',
+        ],
+        shippingEstimate: 'Expédition groupée sous 7 à 12 jours ouvrés',
+        badges: ['Économie combinée'],
+        accent: 'from-fuchsia-500/20 via-rose-500/20 to-amber-500/20',
+        accentSoft: 'bg-fuchsia-500/10',
+        emoji: '🎁',
+        stripePriceKey: 'pack',
+      },
+    ];
+
+    return definitions.map<InternalProduct>((definition) => ({
+      ...definition,
+      stripePriceId: definition.stripePriceKey
+        ? shop.stripe.priceIds[definition.stripePriceKey] || undefined
+        : undefined,
+    }));
+  }
+
+  private initializeStripe(): Stripe | null {
+    const secretKey = this.config.shop.stripe.secretKey;
+    if (!secretKey) {
+      return null;
+    }
+
+    try {
+      return new Stripe(secretKey, {
+        telemetry: false,
+        appInfo: {
+          name: 'Libre Antenne Shop',
+        },
+      });
+    } catch (error) {
+      console.warn('Stripe initialisation failed', error);
+      return null;
+    }
+  }
+
+  private initializeCoingateBaseUrl(): string | null {
+    if (!this.config.shop.coingate.apiKey) {
+      return null;
+    }
+
+    return this.config.shop.coingate.environment === 'live'
+      ? 'https://api.coingate.com/v2'
+      : 'https://api-sandbox.coingate.com/v2';
+  }
+
+  private computeAvailableProviders(product: InternalProduct): ShopProvider[] {
+    const providers: ShopProvider[] = [];
+    if (this.stripe && product.stripePriceId) {
+      providers.push('stripe');
+    }
+    if (this.coingateApiBase && this.config.shop.coingate.apiKey) {
+      providers.push('coingate');
+    }
+    return providers;
+  }
+
+  private formatPrice(priceCents: number, currency: string): string {
+    try {
+      return new Intl.NumberFormat(this.config.shop.locale, {
+        style: 'currency',
+        currency: currency.toUpperCase(),
+        minimumFractionDigits: 2,
+      }).format(priceCents / 100);
+    } catch (error) {
+      console.warn('Price formatting failed', error);
+      return `${(priceCents / 100).toFixed(2)} ${currency.toUpperCase()}`;
+    }
+  }
+
+  private async createStripeCheckout(
+    product: InternalProduct,
+    options: CheckoutRequestOptions,
+  ): Promise<CheckoutSession> {
+    if (!this.stripe) {
+      throw new ShopError('STRIPE_DISABLED', 'Stripe est indisponible.', 503);
+    }
+
+    if (!product.stripePriceId) {
+      throw new ShopError(
+        'STRIPE_PRICE_MISSING',
+        'Aucun prix Stripe configuré pour ce produit.',
+        503,
+      );
+    }
+
+    const successUrl = this.ensureValidReturnUrl(options.successUrl, 'success');
+    const cancelUrl = this.ensureValidReturnUrl(options.cancelUrl, 'cancel');
+
+    try {
+      const session = await this.stripe.checkout.sessions.create({
+        mode: 'payment',
+        line_items: [
+          {
+            price: product.stripePriceId,
+            quantity: 1,
+          },
+        ],
+        success_url: successUrl,
+        cancel_url: cancelUrl,
+        customer_email: options.customerEmail,
+        allow_promotion_codes: true,
+        billing_address_collection: 'auto',
+        metadata: {
+          productId: product.id,
+        },
+      });
+
+      if (!session.url) {
+        throw new ShopError(
+          'STRIPE_URL_MISSING',
+          'Impossible de récupérer le lien de paiement Stripe.',
+          503,
+        );
+      }
+
+      return { provider: 'stripe', url: session.url };
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Erreur inconnue lors de la création de la session Stripe.';
+      throw new ShopError('STRIPE_CHECKOUT_FAILED', message, 502);
+    }
+  }
+
+  private async createCoingateCheckout(
+    product: InternalProduct,
+    options: CheckoutRequestOptions,
+  ): Promise<CheckoutSession> {
+    const apiKey = this.config.shop.coingate.apiKey;
+    if (!apiKey || !this.coingateApiBase) {
+      throw new ShopError('COINGATE_DISABLED', 'CoinGate est indisponible.', 503);
+    }
+
+    const successUrl = this.ensureValidReturnUrl(options.successUrl, 'success');
+    const cancelUrl = this.ensureValidReturnUrl(options.cancelUrl, 'cancel');
+
+    const orderPayload = {
+      order_id: `${product.id}-${Date.now()}`,
+      price_amount: (product.priceCents / 100).toFixed(2),
+      price_currency: product.currency.toUpperCase(),
+      receive_currency: 'keep',
+      title: product.name,
+      description: product.description,
+      success_url: successUrl,
+      cancel_url: cancelUrl,
+      callback_url: this.config.shop.coingate.callbackUrl ?? successUrl,
+    };
+
+    try {
+      const response = await fetch(`${this.coingateApiBase}/orders`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Token ${apiKey}`,
+        },
+        body: JSON.stringify(orderPayload),
+      });
+
+      if (!response.ok) {
+        const errorBody = (await this.safeReadJson(response)) as { message?: string } | null;
+        const message =
+          typeof errorBody?.message === 'string'
+            ? errorBody.message
+            : `CoinGate a répondu avec le statut ${response.status}.`;
+        throw new ShopError('COINGATE_CHECKOUT_FAILED', message, 502);
+      }
+
+      const payload = (await response.json()) as { payment_url?: string };
+      if (!payload?.payment_url) {
+        throw new ShopError(
+          'COINGATE_URL_MISSING',
+          'Impossible de récupérer le lien de paiement CoinGate.',
+          503,
+        );
+      }
+
+      return { provider: 'coingate', url: payload.payment_url };
+    } catch (error) {
+      if (error instanceof ShopError) {
+        throw error;
+      }
+
+      const message =
+        error instanceof Error
+          ? error.message
+          : 'Erreur inconnue lors de la création de la commande CoinGate.';
+      throw new ShopError('COINGATE_CHECKOUT_FAILED', message, 502);
+    }
+  }
+
+  private ensureValidReturnUrl(value: string | undefined, type: 'success' | 'cancel'): string {
+    if (!value) {
+      throw new ShopError('RETURN_URL_REQUIRED', `L'URL de redirection (${type}) est obligatoire.`, 400);
+    }
+
+    try {
+      const parsed = new URL(value);
+      if (!['http:', 'https:'].includes(parsed.protocol)) {
+        throw new Error('Invalid protocol');
+      }
+      return parsed.toString();
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : "L'URL de redirection fournie est invalide.";
+      throw new ShopError('RETURN_URL_INVALID', message, 400);
+    }
+  }
+
+  private async safeReadJson(response: Response): Promise<unknown> {
+    try {
+      return await response.json();
+    } catch (error) {
+      console.warn('Unable to parse CoinGate error body', error);
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a ShopService to manage the merchandise catalog and initiate Stripe/CoinGate checkout sessions
- expose shop API endpoints and configuration for payment providers
- build the Boutique page with product cards, provider buttons, and feedback states

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d95bf25de483248542fe072e63ea33