### PR TITLE
Add ban management page with updated pricing

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1416,6 +1416,51 @@
         error: 'border-rose-400/40 bg-rose-500/10 text-rose-100',
       };
 
+      const BAN_TIERS = [
+        {
+          id: 'ban-60s',
+          duration: '60 secondes',
+          price: '1,10\u00A0€',
+          description: 'Un rappel express pour calmer les débordements immédiats.',
+          accent: 'border-emerald-400/40 bg-emerald-500/10',
+        },
+        {
+          id: 'ban-5m',
+          duration: '5 minutes',
+          price: '2,20\u00A0€',
+          description: 'Idéal pour faire retomber la pression et rétablir le calme.',
+          accent: 'border-sky-400/40 bg-sky-500/10',
+        },
+        {
+          id: 'ban-10m',
+          duration: '10 minutes',
+          price: '3,30\u00A0€',
+          description: 'Parfait pour rappeler les règles sans exclure définitivement.',
+          accent: 'border-indigo-400/40 bg-indigo-500/10',
+        },
+        {
+          id: 'ban-1h',
+          duration: '1 heure',
+          price: '11,00\u00A0€',
+          description: 'Temps suffisant pour protéger la discussion et consulter l’équipe.',
+          accent: 'border-fuchsia-400/40 bg-fuchsia-500/10',
+        },
+        {
+          id: 'ban-24h',
+          duration: '24 heures',
+          price: '22,00\u00A0€',
+          description: 'Mesure ferme pour les récidivistes ou incidents graves.',
+          accent: 'border-amber-400/40 bg-amber-500/10',
+        },
+        {
+          id: 'ban-1w',
+          duration: '1 semaine',
+          price: '55,00\u00A0€',
+          description: 'Sanction longue durée pour comportements incompatibles avec la vibe.',
+          accent: 'border-rose-400/40 bg-rose-500/10',
+        },
+      ];
+
       const parseCheckoutFeedback = () => {
         if (typeof window === 'undefined') {
           return null;
@@ -1768,6 +1813,7 @@
       const NAV_LINKS = [
         { label: 'Accueil', route: 'home', hash: '#/' },
         { label: 'Boutique', route: 'shop', hash: '#/boutique' },
+        { label: 'Bannir un membre', route: 'ban', hash: '#/bannir' },
         { label: 'À propos', route: 'about', hash: '#/about' },
       ];
 
@@ -1779,6 +1825,9 @@
         }
         if (path === '/boutique' || path === 'boutique') {
           return 'shop';
+        }
+        if (path === '/bannir' || path === 'bannir' || path === '/ban' || path === 'ban') {
+          return 'ban';
         }
         return 'home';
       };
@@ -2296,6 +2345,117 @@
         `;
       };
 
+      const BanPage = () => html`
+        <${Fragment}>
+          <section class="space-y-6 rounded-3xl border border-white/10 bg-white/5 px-8 py-12 shadow-xl shadow-slate-950/40 backdrop-blur-xl">
+            <p class="text-xs uppercase tracking-[0.35em] text-slate-300">Modération</p>
+            <h1 class="text-4xl font-bold tracking-tight text-white sm:text-5xl">Bannir un membre</h1>
+            <p class="text-base leading-relaxed text-slate-200">
+              Besoin d’écarter un fauteur de trouble sans casser l’ambiance&nbsp;? Voici le barème officiel pour
+              déléguer un bannissement à l’équipe Libre Antenne. Chaque palier inclut le suivi du dossier, la
+              communication avec les concernés et un rapport rapide dans le canal staff.
+            </p>
+            <p class="flex items-center gap-3 rounded-2xl border border-fuchsia-400/40 bg-fuchsia-500/15 px-4 py-3 text-sm text-fuchsia-100 shadow-lg shadow-fuchsia-900/30">
+              <${ShieldCheck} class="h-4 w-4" aria-hidden="true" />
+              <span>Tarification calculée sur la base Triskel, majorée de 10&nbsp;% pour la gestion opérationnelle.</span>
+            </p>
+            <div class="flex flex-wrap gap-3 text-xs text-slate-200">
+              <span class="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/10 px-4 py-1.5">
+                <${MicOff} class="h-4 w-4" aria-hidden="true" />
+                Exécution immédiate
+              </span>
+              <span class="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/10 px-4 py-1.5">
+                <${ShieldCheck} class="h-4 w-4" aria-hidden="true" />
+                Process encadré
+              </span>
+              <span class="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/10 px-4 py-1.5">
+                <${Sparkles} class="h-4 w-4" aria-hidden="true" />
+                Rapport modération inclus
+              </span>
+            </div>
+          </section>
+
+          <section class="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+            ${BAN_TIERS.map(
+              (tier) => html`<article
+                key=${tier.id}
+                class="flex h-full flex-col rounded-3xl border border-white/10 bg-black/40 p-6 shadow-lg shadow-slate-950/40 backdrop-blur"
+              >
+                <p class="text-xs uppercase tracking-[0.35em] text-slate-300">Option bannissement</p>
+                <h3 class="mt-2 text-lg font-semibold text-white">${tier.duration}</h3>
+                <p class="mt-3 text-sm leading-relaxed text-slate-300">${tier.description}</p>
+                <div class=${`mt-5 rounded-2xl border px-4 py-4 text-center ${tier.accent}`}>
+                  <p class="text-3xl font-bold text-white">${tier.price}</p>
+                  <p class="mt-1 text-xs uppercase tracking-[0.35em] text-slate-200">TTC</p>
+                  <p class="sr-only">Tarif incluant la majoration de 10&nbsp;%.</p>
+                </div>
+                <div class="mt-5 flex items-center gap-2 text-xs text-slate-400">
+                  <${ShieldCheck} class="h-4 w-4 text-emerald-300" aria-hidden="true" />
+                  <span>Application confirmée après validation avec le staff.</span>
+                </div>
+              </article>`,
+            )}
+          </section>
+
+          <section class="grid gap-6 lg:grid-cols-2">
+            <div class="space-y-4 rounded-3xl border border-white/10 bg-white/5 p-6 shadow-lg shadow-slate-950/40 backdrop-blur">
+              <h2 class="flex items-center gap-2 text-xl font-semibold text-white">
+                <${ShieldCheck} class="h-5 w-5 text-emerald-300" aria-hidden="true" />
+                Comment ça marche&nbsp;?
+              </h2>
+              <ol class="space-y-3 pl-5 text-sm leading-relaxed text-slate-200 marker:text-fuchsia-200">
+                <li>
+                  Ouvre un ticket staff sur Discord en précisant le pseudo, la durée souhaitée et le motif du bannissement.
+                </li>
+                <li>
+                  Règle le montant correspondant au palier choisi via la boutique (Stripe, PayPal ou CoinGate).
+                </li>
+                <li>
+                  La modération applique la sanction, documente l’action et te confirme le suivi dans la foulée.
+                </li>
+              </ol>
+            </div>
+            <div class="space-y-4 rounded-3xl border border-white/10 bg-slate-950/60 p-6 shadow-lg shadow-slate-950/50 backdrop-blur">
+              <h2 class="flex items-center gap-2 text-xl font-semibold text-white">
+                <${AlertCircle} class="h-5 w-5 text-amber-300" aria-hidden="true" />
+                Bon à savoir
+              </h2>
+              <ul class="space-y-3 text-sm leading-relaxed text-slate-200">
+                <li>
+                  Les durées sont cumulables si la situation exige un bannissement plus long que le barème standard.
+                </li>
+                <li>
+                  Aucun bannissement n’est appliqué sans trace écrite&nbsp;: un log privé reste disponible pour l’équipe.
+                </li>
+                <li>
+                  En cas de litige, le staff se réserve le droit de prolonger ou d’annuler la sanction après enquête.
+                </li>
+              </ul>
+            </div>
+          </section>
+
+          <section class="rounded-3xl border border-white/10 bg-black/50 p-6 shadow-lg shadow-slate-950/40 backdrop-blur">
+            <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+              <div class="space-y-2">
+                <h2 class="text-xl font-semibold text-white">Prêt à lancer la procédure&nbsp;?</h2>
+                <p class="text-sm leading-relaxed text-slate-300">
+                  Contacte immédiatement la modération pour confirmer les détails et sécuriser la communauté.
+                </p>
+              </div>
+              <a
+                class="inline-flex items-center gap-2 rounded-full border border-fuchsia-400/50 bg-fuchsia-500/20 px-5 py-2 text-sm font-semibold text-fuchsia-100 shadow-lg shadow-fuchsia-900/30 transition hover:bg-fuchsia-500/30 hover:text-white"
+                href="https://discord.gg/btjTZ5C"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Contacter la modération
+                <${ArrowRight} class="h-4 w-4" aria-hidden="true" />
+              </a>
+            </div>
+          </section>
+        </${Fragment}>
+      `;
+
       const AboutPage = () => html`
         <${Fragment}>
           <section class="space-y-6 rounded-3xl border border-white/10 bg-white/5 px-8 py-12 shadow-xl shadow-slate-950/40 backdrop-blur-xl">
@@ -2772,7 +2932,9 @@
               <main class="flex-1 px-6 pb-16 pt-8 sm:px-10">
                 <div class="mx-auto flex max-w-5xl flex-col gap-10">
                   ${
-                    route === 'about'
+                    route === 'ban'
+                      ? html`<${BanPage} />`
+                      : route === 'about'
                       ? html`<${AboutPage} />`
                       : route === 'shop'
                       ? html`<${ShopPage} />`


### PR DESCRIPTION
## Summary
- add a dedicated "Bannir un membre" page with guidance for requesting moderation bans
- display each ban duration with the requested 10% surcharge applied to the Triskel rates
- expose the new page in the navigation and hash routing system

## Testing
- npm run build *(fails: Cannot find module 'stripe' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68d96076bd9c8324aee6b54f7265170e