### PR TITLE
Remove visible nbsp entities and outdated pricing notice

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2351,13 +2351,9 @@
             <p class="text-xs uppercase tracking-[0.35em] text-slate-300">Modération</p>
             <h1 class="text-4xl font-bold tracking-tight text-white sm:text-5xl">Bannir un membre</h1>
             <p class="text-base leading-relaxed text-slate-200">
-              Besoin d’écarter un fauteur de trouble sans casser l’ambiance&nbsp;? Voici le barème officiel pour
+              Besoin d’écarter un fauteur de trouble sans casser l’ambiance ? Voici le barème officiel pour
               déléguer un bannissement à l’équipe Libre Antenne. Chaque palier inclut le suivi du dossier, la
               communication avec les concernés et un rapport rapide dans le canal staff.
-            </p>
-            <p class="flex items-center gap-3 rounded-2xl border border-fuchsia-400/40 bg-fuchsia-500/15 px-4 py-3 text-sm text-fuchsia-100 shadow-lg shadow-fuchsia-900/30">
-              <${ShieldCheck} class="h-4 w-4" aria-hidden="true" />
-              <span>Tarification calculée sur la base Triskel, majorée de 10&nbsp;% pour la gestion opérationnelle.</span>
             </p>
             <div class="flex flex-wrap gap-3 text-xs text-slate-200">
               <span class="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/10 px-4 py-1.5">
@@ -2387,7 +2383,7 @@
                 <div class=${`mt-5 rounded-2xl border px-4 py-4 text-center ${tier.accent}`}>
                   <p class="text-3xl font-bold text-white">${tier.price}</p>
                   <p class="mt-1 text-xs uppercase tracking-[0.35em] text-slate-200">TTC</p>
-                  <p class="sr-only">Tarif incluant la majoration de 10&nbsp;%.</p>
+                  <p class="sr-only">Tarif incluant la majoration de 10 %.</p>
                 </div>
                 <div class="mt-5 flex items-center gap-2 text-xs text-slate-400">
                   <${ShieldCheck} class="h-4 w-4 text-emerald-300" aria-hidden="true" />
@@ -2401,7 +2397,7 @@
             <div class="space-y-4 rounded-3xl border border-white/10 bg-white/5 p-6 shadow-lg shadow-slate-950/40 backdrop-blur">
               <h2 class="flex items-center gap-2 text-xl font-semibold text-white">
                 <${ShieldCheck} class="h-5 w-5 text-emerald-300" aria-hidden="true" />
-                Comment ça marche&nbsp;?
+                Comment ça marche ?
               </h2>
               <ol class="space-y-3 pl-5 text-sm leading-relaxed text-slate-200 marker:text-fuchsia-200">
                 <li>
@@ -2425,7 +2421,7 @@
                   Les durées sont cumulables si la situation exige un bannissement plus long que le barème standard.
                 </li>
                 <li>
-                  Aucun bannissement n’est appliqué sans trace écrite&nbsp;: un log privé reste disponible pour l’équipe.
+                  Aucun bannissement n’est appliqué sans trace écrite : un log privé reste disponible pour l’équipe.
                 </li>
                 <li>
                   En cas de litige, le staff se réserve le droit de prolonger ou d’annuler la sanction après enquête.
@@ -2437,7 +2433,7 @@
           <section class="rounded-3xl border border-white/10 bg-black/50 p-6 shadow-lg shadow-slate-950/40 backdrop-blur">
             <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
               <div class="space-y-2">
-                <h2 class="text-xl font-semibold text-white">Prêt à lancer la procédure&nbsp;?</h2>
+                <h2 class="text-xl font-semibold text-white">Prêt à lancer la procédure ?</h2>
                 <p class="text-sm leading-relaxed text-slate-300">
                   Contacte immédiatement la modération pour confirmer les détails et sécuriser la communauté.
                 </p>

--- a/public/offline.html
+++ b/public/offline.html
@@ -77,7 +77,7 @@
   <body>
     <main>
       <h1>Connexion perdue</h1>
-      <p>Impossible de joindre Libre Antenne. Pas de panique&nbsp;! L'application fonctionne même hors ligne.</p>
+      <p>Impossible de joindre Libre Antenne. Pas de panique ! L'application fonctionne même hors ligne.</p>
       <p>Revenez quand la connexion sera rétablie ou réessayez maintenant.</p>
       <div class="actions">
         <a href="/">Réessayer</a>


### PR DESCRIPTION
## Summary
- replace visible `&nbsp;` entities in ban flow copy with regular spacing
- remove the outdated pricing notice and adjust related accessibility text
- clean up offline fallback message punctuation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9645302c8832498abdd690a8f97bc