### PR TITLE
Add moderation role product to shop

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -114,6 +114,7 @@ const config: Config = {
         mug: process.env.SHOP_STRIPE_PRICE_MUG,
         tshirt: process.env.SHOP_STRIPE_PRICE_TSHIRT,
         pack: process.env.SHOP_STRIPE_PRICE_PACK,
+        moderation: process.env.SHOP_STRIPE_PRICE_MODERATION,
       }).reduce<Record<string, string>>((acc, [key, value]) => {
         if (value) {
           acc[key] = value;

--- a/src/services/ShopService.ts
+++ b/src/services/ShopService.ts
@@ -194,6 +194,25 @@ export default class ShopService {
         emoji: '🎁',
         stripePriceKey: 'pack',
       },
+      {
+        id: 'option-moderation',
+        name: 'Option Modération',
+        description:
+          'Deviens modérateur et participe activement à la protection de la communauté Libre Antenne.',
+        priceCents: 2500,
+        currency: shop.currency,
+        includes: [
+          'Attribution du rôle Modérateur sur le serveur Discord',
+          'Accès aux salons privés de coordination',
+          'Session d’accueil pour découvrir les outils et bonnes pratiques',
+        ],
+        shippingEstimate: 'Activation sous 24 h (aucune livraison physique)',
+        badges: ['Rôle communautaire'],
+        accent: 'from-emerald-500/20 via-lime-500/20 to-teal-500/20',
+        accentSoft: 'bg-emerald-500/10',
+        emoji: '🛡️',
+        stripePriceKey: 'moderation',
+      },
     ];
 
     return definitions.map<InternalProduct>((definition) => ({


### PR DESCRIPTION
## Summary
- add a moderation product to the shop inventory so community members can obtain the moderator role
- expose a Stripe price mapping for the new moderation option in the configuration

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dad4a8a7c88324a78cc8e5659d4b20