### PR TITLE
Fix visible non-breaking spaces in moderation section

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2366,7 +2366,7 @@
             <h1 class="text-4xl font-bold tracking-tight text-white sm:text-5xl">Actions de modération</h1>
             <p class="text-base leading-relaxed text-slate-200">
               Besoin d’écarter un fauteur de trouble sans casser l’ambiance ? Choisis la sanction la plus adaptée.
-              Mute express ou bannissement encadré&nbsp;: l’équipe Libre Antenne se charge de l’exécution, du suivi et
+              Mute express ou bannissement encadré : l’équipe Libre Antenne se charge de l’exécution, du suivi et
               du rapport staff.
             </p>
             <div class="flex flex-wrap gap-3 text-xs text-slate-200">
@@ -2388,7 +2388,7 @@
           <section class="space-y-6 rounded-3xl border border-indigo-400/30 bg-indigo-500/10 p-6 shadow-lg shadow-indigo-900/30 backdrop-blur">
             <div class="space-y-2">
               <p class="text-xs uppercase tracking-[0.35em] text-indigo-200">Nouvelle gamme</p>
-              <h2 class="text-2xl font-semibold text-white">Gamme «&nbsp;Droits de modération&nbsp;»</h2>
+              <h2 class="text-2xl font-semibold text-white">Gamme « Droits de modération »</h2>
               <p class="text-sm leading-relaxed text-indigo-100/80">
                 Active à la demande les actions clés du staff pour garder le contrôle du salon vocal sans attendre.
               </p>
@@ -2494,7 +2494,7 @@
                     Les durées sont cumulables si la situation exige une sanction plus longue que le barème standard.
                   </li>
                   <li>
-                    Aucune action n’est appliquée sans trace écrite&nbsp;: un log privé reste disponible pour l’équipe.
+                    Aucune action n’est appliquée sans trace écrite : un log privé reste disponible pour l’équipe.
                   </li>
                   <li>
                     En cas de litige, le staff se réserve le droit de prolonger ou d’annuler la sanction après enquête.


### PR DESCRIPTION
## Summary
- replace visible HTML non-breaking spaces with standard spacing in the moderation action descriptions
- ensure the “Droits de modération” heading renders without stray entities

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dade29b004832486c3529536bedf55