### PR TITLE
Add nickname data to voice activity history API

### DIFF
--- a/src/http/AppServer.ts
+++ b/src/http/AppServer.ts
@@ -228,6 +228,13 @@ export default class AppServer {
             endedAt: entry.endedAt.toISOString(),
             startedAtMs: entry.startedAt.getTime(),
             endedAtMs: entry.endedAt.getTime(),
+            profile: entry.profile
+              ? {
+                  displayName: entry.profile.displayName,
+                  username: entry.profile.username,
+                  avatar: entry.profile.avatar,
+                }
+              : null,
           })),
         });
       } catch (error) {


### PR DESCRIPTION
## Summary
- include profile metadata when loading voice activity history by joining the users table
- normalize stored nicknames/usernames and expose them through the history API response

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc0208b4a48324b15d6f03bed7421f