### PR TITLE
Cache hype leaderboard response and load Tailwind CSS eagerly

### DIFF
--- a/public/classements.html
+++ b/public/classements.html
@@ -20,7 +20,7 @@
         rel="stylesheet"
       />
     </noscript>
-    <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio" defer></script>
+    <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
     <script>
       window.tailwind = window.tailwind || {};
       window.tailwind.config = {

--- a/public/index.html
+++ b/public/index.html
@@ -61,7 +61,7 @@
       content="Rejoins le flux audio Libre Antenne pour partager ta voix en direct et écouter la communauté."
     />
     <meta name="twitter:image" content="https://libre-antenne.xyz/icons/icon-512.png" />
-    <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio" defer></script>
+    <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",


### PR DESCRIPTION
## Summary
- add short-lived caching and shared promise handling for hype leaderboard responses
- set client cache headers when returning cached hype data
- load Tailwind CDN stylesheet synchronously so CSS is applied immediately on public pages

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc28dbafe483249368cb17673e9499