### PR TITLE
Add detailed Discord profile view

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -202,7 +202,9 @@
         Activity,
         AlertCircle,
         BadgeCheck,
+        ArrowLeft,
         ArrowRight,
+        CalendarDays,
         Clock3,
         Coffee,
         Coins,
@@ -222,6 +224,7 @@
         Truck,
         Users,
         Wallet,
+        MessageSquare,
         Video,
         Volume,
         Volume1,
@@ -283,6 +286,47 @@
         });
       };
 
+      const parseRangeValue = (value) => {
+        if (value instanceof Date) {
+          const time = value.getTime();
+          return Number.isNaN(time) ? null : time;
+        }
+        if (typeof value === 'number' && Number.isFinite(value)) {
+          return value;
+        }
+        if (typeof value === 'string') {
+          const trimmed = value.trim();
+          if (!trimmed) {
+            return null;
+          }
+          const numeric = Number(trimmed);
+          if (Number.isFinite(numeric)) {
+            return numeric;
+          }
+          const parsed = Date.parse(trimmed);
+          if (Number.isFinite(parsed)) {
+            return parsed;
+          }
+        }
+        return null;
+      };
+
+      const buildProfileHash = (userId, sinceMs, untilMs) => {
+        if (!userId) {
+          return '#/profil';
+        }
+        const base = `#/profil/${encodeURIComponent(userId)}`;
+        const params = new URLSearchParams();
+        if (Number.isFinite(sinceMs)) {
+          params.set('since', String(Math.floor(sinceMs)));
+        }
+        if (Number.isFinite(untilMs)) {
+          params.set('until', String(Math.floor(untilMs)));
+        }
+        const query = params.toString();
+        return query ? `${base}?${query}` : base;
+      };
+
       const TALK_WINDOW_OPTIONS = [5, 10, 15, 30, 60];
       const DEFAULT_WINDOW_MINUTES = TALK_WINDOW_OPTIONS.includes(15) ? 15 : TALK_WINDOW_OPTIONS[0];
       const HISTORY_RETENTION_MS = Math.max(
@@ -291,7 +335,9 @@
       );
       const HOURS_IN_DAY = 24;
       const HOUR_MS = 60 * 60 * 1000;
+      const DAY_MS = 24 * HOUR_MS;
       const FALLBACK_SEGMENT_MS = 1000;
+      const DEFAULT_PROFILE_RANGE_MS = 24 * HOUR_MS;
 
       const sanitizeProfile = (raw = {}) => {
         const displayName = typeof raw.displayName === 'string' && raw.displayName.trim().length > 0 ? raw.displayName.trim() : null;
@@ -476,7 +522,7 @@
         return containerRef;
       };
 
-      const SpeakerCard = ({ speaker, now, cardId }) => {
+      const SpeakerCard = ({ speaker, now, cardId, onViewProfile }) => {
         const voiceState = speaker.voiceState ?? {};
         const isSpeaking = Boolean(speaker.isSpeaking);
         const duration = isSpeaking && speaker.startedAt ? formatDuration(now - speaker.startedAt) : null;
@@ -568,22 +614,50 @@
           voiceBadges.push({ key: 'video', label: 'Caméra', Icon: Video });
         }
 
+        const safeDisplayName = typeof speaker.displayName === 'string' && speaker.displayName.trim().length
+          ? speaker.displayName.trim()
+          : 'Intervenant anonyme';
+        const safeUsername = typeof speaker.username === 'string' && speaker.username.trim().length
+          ? speaker.username.trim()
+          : 'anonyme';
+
+        const handleProfileClick = () => {
+          if (typeof onViewProfile === 'function') {
+            onViewProfile(speaker.id ?? cardId);
+          }
+        };
+
+        const initials = safeDisplayName
+          .split(/\s+/)
+          .map((part) => part[0])
+          .join('')
+          .slice(0, 2)
+          .toUpperCase();
+
         return html`
           <article
-            class=${`speaker-card group relative overflow-hidden rounded-3xl border ${cardAccentClass} p-5 shadow-xl shadow-indigo-900/30 transition duration-300 hover:border-fuchsia-400/60 hover:shadow-glow`}
+            class=${`speaker-card group relative overflow-hidden rounded-3xl border ${cardAccentClass} shadow-xl shadow-indigo-900/30 transition duration-300 hover:border-fuchsia-400/60 hover:shadow-glow`}
             data-state=${cardState}
             data-speaker-id=${cardId ?? speaker.id}
           >
             <div class="absolute -right-14 -top-14 h-32 w-32 rounded-full bg-fuchsia-500/40 blur-3xl transition-opacity duration-300 group-hover:opacity-100"></div>
-            <div class="relative flex items-center gap-5">
+            <button
+              type="button"
+              class="relative z-10 flex w-full items-center gap-5 rounded-3xl px-5 py-5 text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-fuchsia-400/60 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
+              onClick=${handleProfileClick}
+            >
               <div class="relative h-20 w-20 flex-shrink-0">
                 <div class="absolute inset-0 rounded-full bg-gradient-to-br from-fuchsia-500 via-indigo-400 to-sky-400 opacity-60 blur-xl transition group-hover:opacity-90"></div>
-                <img
-                  src=${speaker.avatar}
-                  alt=${`Avatar de ${speaker.displayName}`}
-                  class="relative h-20 w-20 rounded-full border-2 border-white/70 object-cover shadow-lg shadow-fuchsia-900/30"
-                  loading="lazy"
-                />
+                ${speaker.avatar
+                  ? html`<img
+                      src=${speaker.avatar}
+                      alt=${`Avatar de ${safeDisplayName}`}
+                      class="relative h-20 w-20 rounded-full border-2 border-white/70 object-cover shadow-lg shadow-fuchsia-900/30"
+                      loading="lazy"
+                    />`
+                  : html`<div class="relative flex h-20 w-20 items-center justify-center rounded-full border-2 border-white/70 bg-white/10 text-xl font-semibold text-white shadow-inner shadow-slate-950/40">
+                      ${initials || '??'}
+                    </div>`}
                 <div
                   class=${`absolute -bottom-1 -right-1 flex items-center gap-1 rounded-full px-2 py-0.5 text-[0.6rem] font-semibold uppercase tracking-wider shadow-lg ${badgeConfig.classes}`}
                 >
@@ -604,8 +678,8 @@
               </div>
               <div class="relative flex flex-1 flex-col gap-2">
                 <div class="flex flex-wrap items-baseline gap-2">
-                  <h3 class="text-2xl font-semibold text-white">${speaker.displayName}</h3>
-                  <span class="text-sm text-slate-300">@${speaker.username}</span>
+                  <h3 class="text-2xl font-semibold text-white">${safeDisplayName}</h3>
+                  <span class="text-sm text-slate-300">@${safeUsername}</span>
                 </div>
                 <div class="flex flex-wrap items-center gap-3 text-xs text-slate-200">
                   <span class="flex items-center gap-1 rounded-full bg-white/10 px-3 py-1 backdrop-blur">
@@ -630,11 +704,11 @@
                     </div>`
                   : null}
               </div>
-            </div>
+            </button>
           </article>
         `;
       };
-      const SpeakersSection = ({ speakers, now }) => {
+      const SpeakersSection = ({ speakers, now, onViewProfile }) => {
         const speakerIds = useMemo(() => speakers.map((speaker) => String(speaker.id ?? '')), [speakers]);
         const containerRef = useSmoothReorder(speakerIds);
 
@@ -653,7 +727,15 @@
 
         return html`
           <div ref=${containerRef} class="mt-6 grid gap-6 sm:grid-cols-2">
-            ${speakers.map((speaker) => html`<${SpeakerCard} key=${speaker.id} speaker=${speaker} now=${now} cardId=${speaker.id} />`)}
+            ${speakers.map((speaker) =>
+              html`<${SpeakerCard}
+                key=${speaker.id}
+                speaker=${speaker}
+                now=${now}
+                cardId=${speaker.id}
+                onViewProfile=${onViewProfile}
+              />`,
+            )}
           </div>
         `;
       };
@@ -955,7 +1037,17 @@
                   ${topSpeaker
                     ? html`<div class="flex flex-col text-xs text-slate-300">
                         <span class="font-semibold text-white">Top voix</span>
-                        <span>${topSpeaker.label}</span>
+                        <button
+                          type="button"
+                          class="mt-1 inline-flex w-max items-center gap-1 rounded-full border border-white/20 bg-white/10 px-2.5 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.3em] text-white transition hover:border-fuchsia-400/40 hover:bg-fuchsia-500/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-fuchsia-400/60 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
+                          onClick=${() => {
+                            if (typeof onViewProfile === 'function') {
+                              onViewProfile(topSpeaker.id);
+                            }
+                          }}
+                        >
+                          ${topSpeaker.label}
+                        </button>
                       </div>`
                     : null}
                 </div>
@@ -969,9 +1061,15 @@
                         const widthPercent = item.duration > 0 ? Math.max(4, rawWidth) : 0;
                         const durationLabel = formatDuration(item.duration);
                         return html`
-                          <div
+                          <button
                             key=${item.id}
-                            class="group rounded-2xl border border-white/10 bg-white/5 p-4 transition hover:border-fuchsia-400/40 hover:bg-fuchsia-500/10"
+                            type="button"
+                            class="group flex w-full flex-col gap-3 rounded-2xl border border-white/10 bg-white/5 p-4 text-left transition hover:border-fuchsia-400/40 hover:bg-fuchsia-500/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-fuchsia-400/60 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
+                            onClick=${() => {
+                              if (typeof onViewProfile === 'function') {
+                                onViewProfile(item.id);
+                              }
+                            }}
                           >
                             <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                               <div class="flex items-center gap-3">
@@ -987,13 +1085,13 @@
                               </div>
                               <div class="text-sm font-semibold text-indigo-200">${percentageFor(item.duration)}</div>
                             </div>
-                            <div class="mt-3 h-2 w-full overflow-hidden rounded-full bg-white/10">
+                            <div class="h-2 w-full overflow-hidden rounded-full bg-white/10">
                               <div
                                 class="h-full rounded-full bg-gradient-to-r from-indigo-400 via-fuchsia-400 to-rose-400 shadow-lg shadow-fuchsia-500/40 transition-all duration-500"
                                 style=${{ width: `${widthPercent}%` }}
                               ></div>
                             </div>
-                          </div>
+                          </button>
                         `;
                       })}
                     </div>
@@ -2028,18 +2126,47 @@
       ];
 
       const getRouteFromHash = () => {
-        const hash = window.location.hash.replace(/^#/, '').toLowerCase();
-        const [path] = hash.split('?');
-        if (path === '/about' || path === 'about') {
-          return 'about';
+        const hash = window.location.hash.replace(/^#/, '');
+        if (!hash || hash === '/') {
+          return { name: 'home', params: {} };
         }
-        if (path === '/boutique' || path === 'boutique') {
-          return 'shop';
+
+        const [pathPart, queryString] = hash.split('?');
+        const segments = pathPart
+          .split('/')
+          .map((segment) => segment.trim())
+          .filter((segment) => segment.length > 0);
+        const search = new URLSearchParams(queryString || '');
+
+        if (segments.length === 0) {
+          return { name: 'home', params: {} };
         }
-        if (path === '/bannir' || path === 'bannir' || path === '/ban' || path === 'ban') {
-          return 'ban';
+
+        const head = segments[0].toLowerCase();
+
+        if (head === 'about') {
+          return { name: 'about', params: {} };
         }
-        return 'home';
+        if (head === 'boutique') {
+          return { name: 'shop', params: {} };
+        }
+        if (head === 'bannir' || head === 'ban') {
+          return { name: 'ban', params: {} };
+        }
+        if (head === 'profil' || head === 'profile') {
+          const userId = segments.length > 1 ? decodeURIComponent(segments[1]) : null;
+          const since = search.get('since');
+          const until = search.get('until');
+          return {
+            name: 'profile',
+            params: { userId, since, until },
+          };
+        }
+        if (head === 'home') {
+          return { name: 'home', params: {} };
+        }
+
+        return { name: 'home', params: {} };
       };
 
       const AudioPlayer = ({ streamInfo, audioKey, status }) => {
@@ -2462,6 +2589,7 @@
         speakingHistory,
         selectedWindowMinutes,
         onWindowChange,
+        onViewProfile,
       }) => {
         const connectedCount = speakers.length;
         const activeSpeakersCount = speakers.reduce(
@@ -2551,8 +2679,972 @@
                 </span>
               </div>
             </div>
-            <${SpeakersSection} speakers=${speakers} now=${now} />
+            <${SpeakersSection} speakers=${speakers} now=${now} onViewProfile=${onViewProfile} />
           </section>
+          </${Fragment}>
+        `;
+      };
+
+      const PROFILE_RANGE_PRESETS = [
+        { label: '24h', description: 'Dernières 24 heures', durationMs: 24 * HOUR_MS },
+        { label: '48h', description: 'Dernières 48 heures', durationMs: 48 * HOUR_MS },
+        { label: '7 j', description: '7 derniers jours', durationMs: 7 * DAY_MS },
+        { label: '30 j', description: '30 derniers jours', durationMs: 30 * DAY_MS },
+      ];
+
+      const toInputValue = (ms) => {
+        if (!Number.isFinite(ms)) {
+          return '';
+        }
+        try {
+          const iso = new Date(ms).toISOString();
+          return iso.slice(0, 16);
+        } catch (error) {
+          console.warn('Impossible de formater la valeur datetime', error);
+          return '';
+        }
+      };
+
+      const formatDateTimeLabel = (ms, { includeDate = true, includeSeconds = false } = {}) => {
+        if (!Number.isFinite(ms)) {
+          return '—';
+        }
+        try {
+          const options = includeDate
+            ? { dateStyle: 'medium', timeStyle: includeSeconds ? 'medium' : 'short' }
+            : { timeStyle: includeSeconds ? 'medium' : 'short' };
+          return new Date(ms).toLocaleString('fr-FR', options);
+        } catch (error) {
+          console.warn('Impossible de formater la date', error);
+          return new Date(ms).toISOString();
+        }
+      };
+
+      const formatRangeLabel = (sinceMs, untilMs) => {
+        if (!Number.isFinite(sinceMs) || !Number.isFinite(untilMs)) {
+          return 'Période inconnue';
+        }
+        const sinceDate = new Date(sinceMs);
+        const untilDate = new Date(untilMs);
+        const sameDay = sinceDate.toDateString() === untilDate.toDateString();
+        if (sameDay) {
+          const dateLabel = sinceDate.toLocaleDateString('fr-FR', {
+            weekday: 'long',
+            day: 'numeric',
+            month: 'long',
+          });
+          const from = sinceDate.toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' });
+          const to = untilDate.toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' });
+          return `${dateLabel} · ${from} – ${to}`;
+        }
+        const from = sinceDate.toLocaleString('fr-FR', { dateStyle: 'medium', timeStyle: 'short' });
+        const to = untilDate.toLocaleString('fr-FR', { dateStyle: 'medium', timeStyle: 'short' });
+        return `Du ${from} au ${to}`;
+      };
+
+      const formatDayLabel = (ms) => {
+        if (!Number.isFinite(ms)) {
+          return 'Date inconnue';
+        }
+        const label = new Date(ms).toLocaleDateString('fr-FR', {
+          weekday: 'long',
+          day: 'numeric',
+          month: 'long',
+          year: 'numeric',
+        });
+        return label.charAt(0).toUpperCase() + label.slice(1);
+      };
+
+      const normalizeProfileRange = (params = {}, fallback = {}) => {
+        const now = Date.now();
+        const fallbackUntil = Number.isFinite(fallback.untilMs) ? fallback.untilMs : now;
+        const untilCandidate = parseRangeValue(params.until);
+        const sinceCandidate = parseRangeValue(params.since);
+        const untilMs = Number.isFinite(untilCandidate) ? untilCandidate : fallbackUntil;
+        let sinceMs = Number.isFinite(sinceCandidate) ? sinceCandidate : fallback.sinceMs;
+        if (!Number.isFinite(sinceMs)) {
+          sinceMs = untilMs - DEFAULT_PROFILE_RANGE_MS;
+        }
+        if (!Number.isFinite(sinceMs)) {
+          sinceMs = now - DEFAULT_PROFILE_RANGE_MS;
+        }
+        if (sinceMs >= untilMs) {
+          sinceMs = Math.max(0, untilMs - DEFAULT_PROFILE_RANGE_MS);
+        }
+        return {
+          sinceMs: Math.max(0, sinceMs),
+          untilMs: Math.max(untilMs, sinceMs + 1),
+        };
+      };
+
+      const ProfileIdentityCard = ({ profile, userId }) => {
+        const safeProfile = profile ?? {};
+        const displayName =
+          safeProfile.displayName
+          ?? safeProfile.globalName
+          ?? safeProfile.username
+          ?? (userId ? `Utilisateur ${userId}` : 'Profil Discord');
+        const discriminator = typeof safeProfile.discriminator === 'string' ? safeProfile.discriminator : null;
+        const hasDiscriminator = discriminator && discriminator !== '0';
+        const usernameTag = safeProfile.username
+          ? hasDiscriminator
+            ? `${safeProfile.username}#${discriminator}`
+            : safeProfile.username
+          : null;
+        const guildNickname = safeProfile.guild?.displayName ?? safeProfile.guild?.nickname ?? null;
+        const joinedGuildMs = safeProfile.guild?.joinedAt ? Date.parse(safeProfile.guild.joinedAt) : NaN;
+        const createdMs = safeProfile.createdAt ? Date.parse(safeProfile.createdAt) : NaN;
+        const roles = Array.isArray(safeProfile.guild?.roles) ? safeProfile.guild.roles : [];
+        const initials = displayName
+          .split(/\s+/)
+          .map((part) => part.charAt(0))
+          .filter(Boolean)
+          .join('')
+          .slice(0, 2)
+          .toUpperCase();
+
+        return html`
+          <section class="relative overflow-hidden rounded-3xl border border-white/10 bg-white/5 p-6 shadow-xl shadow-slate-950/40 backdrop-blur-xl">
+            <div class="pointer-events-none absolute -left-24 top-[-5rem] h-64 w-64 rounded-full bg-indigo-500/20 blur-3xl"></div>
+            <div class="pointer-events-none absolute -right-24 bottom-[-6rem] h-64 w-64 rounded-full bg-fuchsia-500/20 blur-[110px]"></div>
+            <div class="relative flex flex-col gap-6 sm:flex-row sm:items-center">
+              <div class="flex-shrink-0">
+                ${safeProfile.avatarUrl
+                  ? html`<img
+                      src=${safeProfile.avatarUrl}
+                      alt=${`Avatar de ${displayName}`}
+                      class="h-24 w-24 rounded-3xl border border-white/20 object-cover shadow-lg shadow-fuchsia-900/30"
+                    />`
+                  : html`<div
+                      class="flex h-24 w-24 items-center justify-center rounded-3xl border border-dashed border-white/20 bg-black/40 text-2xl font-semibold uppercase text-fuchsia-200"
+                    >
+                      ${initials || '??'}
+                    </div>`}
+              </div>
+              <div class="flex flex-1 flex-col gap-3">
+                <div>
+                  <p class="text-xs uppercase tracking-[0.35em] text-indigo-200/80">Profil Discord</p>
+                  <h1 class="text-3xl font-bold text-white sm:text-4xl">${displayName}</h1>
+                  ${usernameTag
+                    ? html`<p class="text-sm text-slate-300">${usernameTag}</p>`
+                    : null}
+                </div>
+                <div class="flex flex-wrap items-center gap-3 text-xs text-slate-200/90">
+                  ${guildNickname && guildNickname !== displayName
+                    ? html`<span class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/10 px-3 py-1 backdrop-blur">
+                        <${BadgeCheck} class="h-3.5 w-3.5 text-emerald-300" aria-hidden="true" />
+                        <span>${guildNickname}</span>
+                      </span>`
+                    : null}
+                  ${userId
+                    ? html`<span class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/10 px-3 py-1 backdrop-blur">
+                        <${Users} class="h-3.5 w-3.5 text-indigo-200" aria-hidden="true" />
+                        <span>ID : ${userId}</span>
+                      </span>`
+                    : null}
+                </div>
+                <div class="grid gap-3 rounded-2xl border border-white/10 bg-slate-950/40 p-4 text-sm text-slate-200 sm:grid-cols-2">
+                  <div class="space-y-1">
+                    <p class="text-xs uppercase tracking-[0.3em] text-slate-400">Compte Discord</p>
+                    <p class="font-semibold text-white">${Number.isFinite(createdMs) ? formatDateTimeLabel(createdMs) : 'Date inconnue'}</p>
+                  </div>
+                  <div class="space-y-1">
+                    <p class="text-xs uppercase tracking-[0.3em] text-slate-400">Arrivée sur le serveur</p>
+                    <p class="font-semibold text-white">
+                      ${Number.isFinite(joinedGuildMs) ? formatDateTimeLabel(joinedGuildMs) : '—'}
+                    </p>
+                  </div>
+                </div>
+                ${roles.length
+                  ? html`<div class="flex flex-wrap gap-2">
+                      ${roles.map(
+                        (role) => html`<span
+                          key=${role.id}
+                          class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/10 px-3 py-1 text-xs font-medium uppercase tracking-[0.2em] text-slate-100 backdrop-blur"
+                        >
+                          #${role.name}
+                        </span>`,
+                      )}
+                    </div>`
+                  : null}
+              </div>
+            </div>
+          </section>
+        `;
+      };
+
+      const ProfileSummaryCards = ({ stats }) => {
+        if (!stats) {
+          return null;
+        }
+
+        const safeDuration = (value) => {
+          const label = formatDuration(value);
+          return label && label.trim().length > 0 ? label : '0s';
+        };
+
+        const presenceSessions = stats.presenceSessions || 0;
+        const speakingSessions = stats.speakingSessions || 0;
+        const messageCount = Number.isFinite(stats.messageCount) ? stats.messageCount : 0;
+        const activeDays = Number.isFinite(stats.activeDayCount) ? stats.activeDayCount : 0;
+
+        const cards = [
+          {
+            key: 'presence',
+            label: 'Temps en vocal',
+            value: safeDuration(stats.totalPresenceMs),
+            subLabel: `${presenceSessions} session${presenceSessions > 1 ? 's' : ''}`,
+            Icon: Headphones,
+          },
+          {
+            key: 'speaking',
+            label: 'Temps de parole',
+            value: safeDuration(stats.totalSpeakingMs),
+            subLabel: `${speakingSessions} intervention${speakingSessions > 1 ? 's' : ''}`,
+            Icon: Mic,
+          },
+          {
+            key: 'messages',
+            label: 'Messages envoyés',
+            value: messageCount,
+            subLabel: 'Sur la période analysée',
+            Icon: MessageSquare,
+          },
+          {
+            key: 'days',
+            label: 'Jours actifs',
+            value: activeDays,
+            subLabel: `${stats.uniqueActiveDays?.length || 0} jours uniques`,
+            Icon: CalendarDays,
+          },
+        ];
+
+        return html`
+          <section class="rounded-3xl border border-white/10 bg-slate-950/60 p-6 shadow-xl shadow-slate-950/40 backdrop-blur-xl">
+            <div class="flex flex-col gap-6">
+              <div>
+                <p class="text-xs uppercase tracking-[0.35em] text-indigo-200/80">Synthèse</p>
+                <h2 class="text-2xl font-semibold text-white">Résumé de l'activité</h2>
+                <p class="text-sm text-slate-300">Une vue rapide de la présence de l'utilisateur sur la période sélectionnée.</p>
+              </div>
+              <div class="grid gap-4 sm:grid-cols-2">
+                ${cards.map(
+                  ({ key, label, value, subLabel, Icon }) => html`<div
+                    key=${key}
+                    class="flex items-start gap-4 rounded-2xl border border-white/10 bg-white/5 p-4 text-sm text-slate-200"
+                  >
+                    <div class="flex h-10 w-10 items-center justify-center rounded-2xl bg-gradient-to-br from-indigo-500/30 via-fuchsia-500/20 to-transparent text-fuchsia-200">
+                      <${Icon} class="h-5 w-5" aria-hidden="true" />
+                    </div>
+                    <div class="space-y-1">
+                      <p class="text-xs uppercase tracking-[0.3em] text-slate-400">${label}</p>
+                      <p class="text-lg font-semibold text-white">${value}</p>
+                      <p class="text-xs text-slate-300">${subLabel}</p>
+                    </div>
+                  </div>`,
+                )}
+              </div>
+              <div class="grid gap-4 rounded-2xl border border-white/10 bg-black/40 p-4 text-xs text-slate-300 sm:grid-cols-2">
+                <div class="space-y-1">
+                  <p class="uppercase tracking-[0.3em] text-slate-400">Première activité</p>
+                  <p class="text-sm font-semibold text-white">
+                    ${stats.firstActivityAt?.ms ? formatDateTimeLabel(stats.firstActivityAt.ms) : '—'}
+                  </p>
+                </div>
+                <div class="space-y-1">
+                  <p class="uppercase tracking-[0.3em] text-slate-400">Dernière activité</p>
+                  <p class="text-sm font-semibold text-white">
+                    ${stats.lastActivityAt?.ms ? formatDateTimeLabel(stats.lastActivityAt.ms) : '—'}
+                  </p>
+                </div>
+              </div>
+            </div>
+          </section>
+        `;
+      };
+
+      const ProfileActivityTimeline = ({ range, presenceSegments = [], speakingSegments = [], messageEvents = [] }) => {
+        const timeline = useMemo(() => {
+          const rangeStart = Number(range?.sinceMs);
+          const rangeEnd = Number(range?.untilMs);
+          if (!Number.isFinite(rangeStart) || !Number.isFinite(rangeEnd) || rangeEnd <= rangeStart) {
+            return {
+              hasValidRange: false,
+              presenceBars: [],
+              speakingBars: [],
+              messagePoints: [],
+              ticks: [],
+            };
+          }
+
+          const duration = rangeEnd - rangeStart;
+
+          const clamp = (start, end) => {
+            const safeStart = Math.max(rangeStart, start);
+            const safeEnd = Math.min(rangeEnd, end);
+            if (!Number.isFinite(safeStart) || !Number.isFinite(safeEnd) || safeEnd <= safeStart) {
+              return null;
+            }
+            return [safeStart, safeEnd];
+          };
+
+          const createBars = (segments, getBounds) => {
+            const bars = [];
+            for (const segment of Array.isArray(segments) ? segments : []) {
+              if (!segment) {
+                continue;
+              }
+              const bounds = getBounds(segment);
+              if (!bounds) {
+                continue;
+              }
+              const [start, end] = bounds;
+              const clamped = clamp(start, end);
+              if (!clamped) {
+                continue;
+              }
+              const [clampedStart, clampedEnd] = clamped;
+              const leftPercent = ((clampedStart - rangeStart) / duration) * 100;
+              const widthPercent = Math.max(((clampedEnd - clampedStart) / duration) * 100, 0.8);
+              bars.push({
+                key: `${clampedStart}-${clampedEnd}-${bars.length}`,
+                start: clampedStart,
+                end: clampedEnd,
+                leftPercent,
+                widthPercent,
+              });
+            }
+            return bars.sort((a, b) => a.start - b.start);
+          };
+
+          const presenceBars = createBars(presenceSegments, (segment) => {
+            const start = Number(segment?.joinedAtMs);
+            const endCandidate = Number(segment?.leftAtMs);
+            const end = Number.isFinite(endCandidate) ? endCandidate : rangeEnd;
+            if (!Number.isFinite(start)) {
+              return null;
+            }
+            return [start, end];
+          });
+
+          const speakingBars = createBars(speakingSegments, (segment) => {
+            const start = Number(segment?.startedAtMs);
+            const durationMs = Number(segment?.durationMs);
+            if (!Number.isFinite(start)) {
+              return null;
+            }
+            const end = Number.isFinite(durationMs) ? start + Math.max(durationMs, 0) : start;
+            return [start, end];
+          });
+
+          const messagePoints = (Array.isArray(messageEvents) ? messageEvents : [])
+            .map((entry, index) => {
+              const timestamp = Number(entry?.timestampMs);
+              if (!Number.isFinite(timestamp) || timestamp < rangeStart || timestamp > rangeEnd) {
+                return null;
+              }
+              const leftPercent = ((timestamp - rangeStart) / duration) * 100;
+              return {
+                key: `${timestamp}-${index}`,
+                timestamp,
+                leftPercent,
+              };
+            })
+            .filter(Boolean)
+            .sort((a, b) => a.timestamp - b.timestamp);
+
+          const tickCount = 6;
+          const ticks = Array.from({ length: tickCount }, (_, index) => {
+            const ratio = tickCount === 1 ? 0 : index / (tickCount - 1);
+            const value = rangeStart + duration * ratio;
+            const label = duration <= 6 * HOUR_MS
+              ? new Date(value).toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' })
+              : new Date(value).toLocaleString('fr-FR', { day: '2-digit', month: 'short', hour: '2-digit', minute: '2-digit' });
+            return {
+              key: `${value}-${index}`,
+              leftPercent: ratio * 100,
+              label,
+            };
+          });
+
+          return {
+            hasValidRange: true,
+            presenceBars,
+            speakingBars,
+            messagePoints,
+            ticks,
+            rangeStart,
+            rangeEnd,
+            duration,
+          };
+        }, [range?.sinceMs, range?.untilMs, presenceSegments, speakingSegments, messageEvents]);
+
+        const hasAnyActivity =
+          timeline.presenceBars.length > 0
+          || timeline.speakingBars.length > 0
+          || timeline.messagePoints.length > 0;
+        const rangeLabel = formatRangeLabel(range?.sinceMs, range?.untilMs);
+
+        return html`
+          <section class="rounded-3xl border border-white/10 bg-white/5 p-6 shadow-xl shadow-slate-950/40 backdrop-blur-xl">
+            <div class="flex flex-col gap-6">
+              <div class="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
+                <div>
+                  <p class="text-xs uppercase tracking-[0.35em] text-indigo-200/80">Chronologie unifiée</p>
+                  <h2 class="text-2xl font-semibold text-white">Activité détaillée</h2>
+                  <p class="text-sm text-slate-300">${rangeLabel}</p>
+                </div>
+                <div class="flex flex-wrap gap-3 text-xs text-slate-300">
+                  <span class="flex items-center gap-2 rounded-full border border-white/10 bg-emerald-500/20 px-3 py-1 text-emerald-100">
+                    <span class="h-2 w-6 rounded-full bg-emerald-300"></span>
+                    Présence vocale
+                  </span>
+                  <span class="flex items-center gap-2 rounded-full border border-white/10 bg-fuchsia-500/20 px-3 py-1 text-fuchsia-100">
+                    <span class="h-2 w-6 rounded-full bg-fuchsia-300"></span>
+                    Parole
+                  </span>
+                  <span class="flex items-center gap-2 rounded-full border border-white/10 bg-indigo-500/20 px-3 py-1 text-indigo-100">
+                    <${MessageSquare} class="h-3.5 w-3.5" aria-hidden="true" />
+                    Messages
+                  </span>
+                </div>
+              </div>
+              <div class="relative overflow-hidden rounded-3xl border border-white/10 bg-slate-950/80 p-6">
+                ${hasAnyActivity && timeline.hasValidRange
+                  ? html`
+                      <div class="relative h-32">
+                        <div class="absolute inset-0">
+                          ${timeline.ticks.map(
+                            (tick) => html`<div
+                              key=${tick.key}
+                              class="absolute inset-y-0 w-px bg-white/5"
+                              style=${{ left: `${tick.leftPercent}%` }}
+                            ></div>`,
+                          )}
+                        </div>
+                        <div class="absolute inset-x-0 top-2 flex h-3 items-center">
+                          <div class="relative h-full w-full rounded-full bg-white/5">
+                            ${timeline.presenceBars.map(
+                              (bar) => html`<span
+                                key=${`presence-${bar.key}`}
+                                class="absolute h-full rounded-full bg-gradient-to-r from-emerald-500/70 via-emerald-400/80 to-emerald-300/80 shadow-[0_0_18px_rgba(16,185,129,0.45)]"
+                                style=${{ left: `${bar.leftPercent}%`, width: `${bar.widthPercent}%` }}
+                                title=${`Présence · ${formatDateTimeLabel(bar.start)} → ${formatDateTimeLabel(bar.end)}`}
+                              ></span>`,
+                            )}
+                          </div>
+                        </div>
+                        <div class="absolute inset-x-0 top-14 flex h-3 items-center">
+                          <div class="relative h-full w-full rounded-full bg-white/5">
+                            ${timeline.speakingBars.map(
+                              (bar) => html`<span
+                                key=${`speaking-${bar.key}`}
+                                class="absolute h-full rounded-full bg-gradient-to-r from-fuchsia-500/80 via-rose-500/80 to-fuchsia-400/80 shadow-[0_0_18px_rgba(236,72,153,0.45)]"
+                                style=${{ left: `${bar.leftPercent}%`, width: `${bar.widthPercent}%` }}
+                                title=${`Parole · ${formatDateTimeLabel(bar.start)} → ${formatDateTimeLabel(bar.end)}`}
+                              ></span>`,
+                            )}
+                          </div>
+                        </div>
+                        <div class="absolute inset-x-0 top-[6.5rem] flex h-4 items-center">
+                          <div class="relative h-full w-full">
+                            ${timeline.messagePoints.map(
+                              (point) => html`<span
+                                key=${`message-${point.key}`}
+                                class="absolute flex h-4 w-4 -translate-x-1/2 items-center justify-center rounded-full bg-indigo-500/30 text-indigo-200"
+                                style=${{ left: `${point.leftPercent}%` }}
+                                title=${`Message · ${formatDateTimeLabel(point.timestamp)}`}
+                              >
+                                <span class="h-2 w-2 rounded-full bg-indigo-300 shadow-[0_0_12px_rgba(129,140,248,0.75)]"></span>
+                              </span>`,
+                            )}
+                          </div>
+                        </div>
+                      </div>
+                      <div class="relative mt-6 h-6 text-[0.7rem] font-semibold uppercase tracking-[0.25em] text-slate-300">
+                        ${timeline.ticks.map(
+                          (tick) => html`<span
+                            key=${`label-${tick.key}`}
+                            class="absolute -translate-x-1/2 whitespace-nowrap"
+                            style=${{ left: `${tick.leftPercent}%` }}
+                          >
+                            ${tick.label}
+                          </span>`,
+                        )}
+                      </div>
+                    `
+                  : html`
+                      <div class="flex h-32 flex-col items-center justify-center gap-3 text-center text-sm text-slate-300">
+                        <div class="flex h-12 w-12 items-center justify-center rounded-full border border-white/10 bg-white/10 text-indigo-200">
+                          <${Clock3} class="h-5 w-5" aria-hidden="true" />
+                        </div>
+                        <p>Aucune activité détectée sur cette période.</p>
+                      </div>
+                    `}
+              </div>
+            </div>
+          </section>
+        `;
+      };
+
+      const DailyBreakdown = ({ range, presenceSegments = [], speakingSegments = [], messageEvents = [] }) => {
+        const rows = useMemo(() => {
+          const rangeStart = Number(range?.sinceMs);
+          const rangeEnd = Number(range?.untilMs);
+          if (!Number.isFinite(rangeStart) || !Number.isFinite(rangeEnd) || rangeEnd <= rangeStart) {
+            return [];
+          }
+
+          const dayMap = new Map();
+
+          const clamp = (start, end) => {
+            const safeStart = Math.max(rangeStart, start);
+            const safeEnd = Math.min(rangeEnd, end);
+            if (!Number.isFinite(safeStart) || !Number.isFinite(safeEnd) || safeEnd <= safeStart) {
+              return null;
+            }
+            return [safeStart, safeEnd];
+          };
+
+          const pushPart = (dayStartMs, durationMs, field) => {
+            if (!Number.isFinite(dayStartMs) || !Number.isFinite(durationMs) || durationMs <= 0) {
+              return;
+            }
+            const key = new Date(dayStartMs).toISOString().slice(0, 10);
+            if (!dayMap.has(key)) {
+              dayMap.set(key, {
+                key,
+                dayStartMs,
+                presenceMs: 0,
+                speakingMs: 0,
+                messageCount: 0,
+              });
+            }
+            const record = dayMap.get(key);
+            record[field] += durationMs;
+          };
+
+          const splitSegment = (start, end, field) => {
+            const clamped = clamp(start, end);
+            if (!clamped) {
+              return;
+            }
+            let [cursor, segmentEnd] = clamped;
+            while (cursor < segmentEnd) {
+              const dayStart = new Date(cursor);
+              dayStart.setHours(0, 0, 0, 0);
+              const dayStartMs = dayStart.getTime();
+              const dayEndMs = dayStartMs + DAY_MS;
+              const chunkEnd = Math.min(segmentEnd, dayEndMs);
+              pushPart(dayStartMs, chunkEnd - cursor, field);
+              cursor = chunkEnd;
+            }
+          };
+
+          for (const segment of Array.isArray(presenceSegments) ? presenceSegments : []) {
+            const start = Number(segment?.joinedAtMs);
+            const endCandidate = Number(segment?.leftAtMs);
+            const end = Number.isFinite(endCandidate) ? endCandidate : rangeEnd;
+            if (!Number.isFinite(start)) {
+              continue;
+            }
+            splitSegment(start, end, 'presenceMs');
+          }
+
+          for (const segment of Array.isArray(speakingSegments) ? speakingSegments : []) {
+            const start = Number(segment?.startedAtMs);
+            const durationMs = Number(segment?.durationMs);
+            if (!Number.isFinite(start)) {
+              continue;
+            }
+            const end = Number.isFinite(durationMs) ? start + Math.max(durationMs, 0) : start;
+            splitSegment(start, end, 'speakingMs');
+          }
+
+          for (const entry of Array.isArray(messageEvents) ? messageEvents : []) {
+            const timestamp = Number(entry?.timestampMs);
+            if (!Number.isFinite(timestamp) || timestamp < rangeStart || timestamp > rangeEnd) {
+              continue;
+            }
+            const dayStart = new Date(timestamp);
+            dayStart.setHours(0, 0, 0, 0);
+            const key = dayStart.toISOString().slice(0, 10);
+            if (!dayMap.has(key)) {
+              dayMap.set(key, {
+                key,
+                dayStartMs: dayStart.getTime(),
+                presenceMs: 0,
+                speakingMs: 0,
+                messageCount: 0,
+              });
+            }
+            dayMap.get(key).messageCount += 1;
+          }
+
+          return Array.from(dayMap.values()).sort((a, b) => b.dayStartMs - a.dayStartMs);
+        }, [range?.sinceMs, range?.untilMs, presenceSegments, speakingSegments, messageEvents]);
+
+        if (!rows.length) {
+          return html`
+            <section class="rounded-3xl border border-white/10 bg-white/5 p-6 text-center shadow-xl shadow-slate-950/40 backdrop-blur-xl text-sm text-slate-300">
+              <div class="mx-auto flex h-12 w-12 items-center justify-center rounded-full border border-white/10 bg-white/10 text-indigo-200">
+                <${Clock3} class="h-5 w-5" aria-hidden="true" />
+              </div>
+              <p class="mt-3 text-base text-slate-200">Aucune donnée quotidienne disponible sur cette période.</p>
+            </section>
+          `;
+        }
+
+        return html`
+          <section class="rounded-3xl border border-white/10 bg-white/5 p-6 shadow-xl shadow-slate-950/40 backdrop-blur-xl">
+            <div class="flex flex-col gap-6">
+              <div>
+                <p class="text-xs uppercase tracking-[0.35em] text-indigo-200/80">Détails jour par jour</p>
+                <h2 class="text-2xl font-semibold text-white">Répartition quotidienne</h2>
+                <p class="text-sm text-slate-300">Identifie rapidement les pics d'activité et les journées silencieuses.</p>
+              </div>
+              <div class="space-y-4">
+                ${rows.map(
+                  (row) => {
+                    const presenceLabel = formatDuration(row.presenceMs) || '0s';
+                    const speakingLabel = formatDuration(row.speakingMs) || '0s';
+                    return html`<article
+                      key=${row.key}
+                      class="flex flex-col gap-3 rounded-2xl border border-white/10 bg-slate-950/70 p-4 text-sm text-slate-200 sm:flex-row sm:items-center sm:justify-between"
+                    >
+                      <div>
+                        <p class="text-base font-semibold text-white">${formatDayLabel(row.dayStartMs)}</p>
+                        <p class="text-xs text-slate-300">
+                          Présence : ${presenceLabel} · Parole : ${speakingLabel}
+                        </p>
+                      </div>
+                      <div class="flex flex-wrap items-center gap-3 text-xs">
+                        <span class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-emerald-500/20 px-3 py-1 text-emerald-100">
+                          <span class="h-2 w-2 rounded-full bg-emerald-300"></span>
+                          ${presenceLabel}
+                        </span>
+                        <span class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-fuchsia-500/20 px-3 py-1 text-fuchsia-100">
+                          <span class="h-2 w-2 rounded-full bg-fuchsia-300"></span>
+                          ${speakingLabel}
+                        </span>
+                        <span class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-indigo-500/20 px-3 py-1 text-indigo-100">
+                          <${MessageSquare} class="h-3.5 w-3.5" aria-hidden="true" />
+                          ${row.messageCount} message${row.messageCount > 1 ? 's' : ''}
+                        </span>
+                      </div>
+                    </article>`;
+                  },
+                )}
+              </div>
+            </div>
+          </section>
+        `;
+      };
+
+      const ProfilePage = ({ params, onNavigateHome, onUpdateRange }) => {
+        const userId = typeof params?.userId === 'string' && params.userId.trim().length > 0 ? params.userId.trim() : null;
+        const [range, setRange] = useState(() => normalizeProfileRange(params ?? {}));
+        const [draftSince, setDraftSince] = useState(() => toInputValue(range.sinceMs));
+        const [draftUntil, setDraftUntil] = useState(() => toInputValue(range.untilMs));
+        const [formError, setFormError] = useState('');
+        const [state, setState] = useState({ status: 'idle', data: null, error: null });
+        const [refreshNonce, setRefreshNonce] = useState(0);
+        const previousUserRef = useRef(userId);
+
+        useEffect(() => {
+          const userChanged = previousUserRef.current !== userId;
+          previousUserRef.current = userId;
+          setRange((prev) => {
+            const fallback = userChanged ? {} : prev || {};
+            const normalized = normalizeProfileRange(params ?? {}, fallback);
+            if (prev && normalized.sinceMs === prev.sinceMs && normalized.untilMs === prev.untilMs) {
+              return prev;
+            }
+            return normalized;
+          });
+        }, [params?.since, params?.until, userId]);
+
+        useEffect(() => {
+          setDraftSince(toInputValue(range.sinceMs));
+          setDraftUntil(toInputValue(range.untilMs));
+        }, [range.sinceMs, range.untilMs]);
+
+        useEffect(() => {
+          if (!userId) {
+            setState({ status: 'idle', data: null, error: null });
+            return undefined;
+          }
+
+          const sinceMs = range.sinceMs;
+          const untilMs = range.untilMs;
+          if (!Number.isFinite(sinceMs) || !Number.isFinite(untilMs) || untilMs <= sinceMs) {
+            return undefined;
+          }
+
+          const controller = typeof AbortController !== 'undefined' ? new AbortController() : null;
+          setState((prev) => ({ status: 'loading', data: prev.data, error: null }));
+
+          const fetchProfile = async () => {
+            try {
+              const query = new URLSearchParams();
+              query.set('since', String(Math.floor(sinceMs)));
+              query.set('until', String(Math.floor(untilMs)));
+              const response = await fetch(`/api/users/${encodeURIComponent(userId)}/profile?${query.toString()}`, {
+                signal: controller?.signal,
+              });
+              if (!response.ok) {
+                let message = "Impossible de récupérer le profil demandé.";
+                let shouldClear = false;
+                try {
+                  const body = await response.json();
+                  if (body?.message) {
+                    message = body.message;
+                  }
+                } catch (error) {
+                  // ignore JSON parsing errors
+                }
+                if (response.status === 404) {
+                  shouldClear = true;
+                  message = 'Profil introuvable sur cette période.';
+                }
+                const error = new Error(message);
+                error.clearData = shouldClear;
+                throw error;
+              }
+
+              const payload = await response.json();
+              setState({ status: 'success', data: payload, error: null });
+            } catch (error) {
+              if (error && typeof error === 'object' && error.name === 'AbortError') {
+                return;
+              }
+              const message = error instanceof Error && error.message
+                ? error.message
+                : 'Impossible de récupérer le profil demandé.';
+              const shouldClear = Boolean(error && typeof error === 'object' && error.clearData);
+              setState((prev) => ({
+                status: 'error',
+                data: shouldClear ? null : prev.data,
+                error: message,
+              }));
+            }
+          };
+
+          fetchProfile();
+          return () => controller?.abort();
+        }, [userId, range.sinceMs, range.untilMs, refreshNonce]);
+
+        const handleBack = useCallback(
+          (event) => {
+            event?.preventDefault?.();
+            if (typeof onNavigateHome === 'function') {
+              onNavigateHome();
+            }
+          },
+          [onNavigateHome],
+        );
+
+        const handlePresetClick = useCallback(
+          (durationMs) => {
+            if (!Number.isFinite(durationMs) || durationMs <= 0) {
+              return;
+            }
+            const nowMs = Date.now();
+            const nextUntil = nowMs;
+            const nextSince = Math.max(0, nextUntil - durationMs);
+            setRange({ sinceMs: nextSince, untilMs: nextUntil });
+            setDraftSince(toInputValue(nextSince));
+            setDraftUntil(toInputValue(nextUntil));
+            setFormError('');
+            if (typeof onUpdateRange === 'function' && userId) {
+              onUpdateRange(userId, nextSince, nextUntil);
+            }
+          },
+          [onUpdateRange, userId],
+        );
+
+        const handleApplyRange = useCallback(
+          (event) => {
+            event?.preventDefault?.();
+            const sinceMs = parseRangeValue(draftSince);
+            const untilMs = parseRangeValue(draftUntil);
+            if (!Number.isFinite(sinceMs) || !Number.isFinite(untilMs)) {
+              setFormError('Merci de renseigner deux dates valides.');
+              return;
+            }
+            if (untilMs <= sinceMs) {
+              setFormError('La date de fin doit être postérieure à la date de début.');
+              return;
+            }
+            setFormError('');
+            setRange({ sinceMs, untilMs });
+            setDraftSince(toInputValue(sinceMs));
+            setDraftUntil(toInputValue(untilMs));
+            if (typeof onUpdateRange === 'function' && userId) {
+              onUpdateRange(userId, sinceMs, untilMs);
+            }
+          },
+          [draftSince, draftUntil, onUpdateRange, userId],
+        );
+
+        const handleRefresh = useCallback(() => {
+          setRefreshNonce((value) => value + 1);
+        }, []);
+
+        const isLoading = state.status === 'loading';
+        const errorMessage = state.status === 'error' ? state.error : null;
+        const data = state.data;
+        const activeRange = data?.range ?? range;
+        const activeDuration = Number.isFinite(range.untilMs) && Number.isFinite(range.sinceMs)
+          ? Math.abs(range.untilMs - range.sinceMs)
+          : null;
+
+        return html`
+          <${Fragment}>
+            <div class="flex items-center justify-between">
+              <button
+                type="button"
+                onClick=${handleBack}
+                class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1.5 text-xs font-semibold text-slate-200 transition hover:bg-white/10 hover:text-white"
+              >
+                <${ArrowLeft} class="h-4 w-4" aria-hidden="true" />
+                Retour
+              </button>
+              ${userId
+                ? html`<span class="text-xs uppercase tracking-[0.35em] text-slate-400">ID ${userId}</span>`
+                : null}
+            </div>
+
+            ${!userId
+              ? html`<section class="mt-6 space-y-4 rounded-3xl border border-white/10 bg-white/5 p-8 text-center shadow-xl shadow-slate-950/40 backdrop-blur-xl">
+                  <h1 class="text-3xl font-semibold text-white">Profil introuvable</h1>
+                  <p class="text-sm text-slate-300">Sélectionne un utilisateur depuis la page d'accueil pour afficher ses statistiques.</p>
+                  <button
+                    type="button"
+                    onClick=${handleBack}
+                    class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-sm font-semibold text-slate-200 transition hover:bg-white/10 hover:text-white"
+                  >
+                    <${ArrowLeft} class="h-4 w-4" aria-hidden="true" />
+                    Retour à l'accueil
+                  </button>
+                </section>`
+              : html`
+                  <div class="mt-6 grid gap-8">
+                    <${ProfileIdentityCard} profile=${data?.profile ?? null} userId=${userId} />
+
+                    <section class="rounded-3xl border border-white/10 bg-white/5 p-6 shadow-xl shadow-slate-950/40 backdrop-blur-xl">
+                      <div class="flex flex-col gap-6">
+                        <div class="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+                          <div>
+                            <p class="text-xs uppercase tracking-[0.35em] text-indigo-200/80">Période analysée</p>
+                            <h2 class="text-2xl font-semibold text-white">Filtrer l'activité</h2>
+                            <p class="text-sm text-slate-300">${formatRangeLabel(range.sinceMs, range.untilMs)}</p>
+                          </div>
+                          <button
+                            type="button"
+                            onClick=${handleRefresh}
+                            class=${[
+                              'inline-flex items-center gap-2 rounded-full border border-white/10 px-3 py-1.5 text-xs font-semibold transition',
+                              'bg-white/5 text-slate-200 hover:bg-white/10 hover:text-white',
+                              isLoading ? 'opacity-60' : '',
+                            ]
+                              .filter(Boolean)
+                              .join(' ')}
+                            disabled=${isLoading}
+                          >
+                            <${RefreshCcw} class=${`h-4 w-4 ${isLoading ? 'animate-spin text-indigo-200' : ''}`} aria-hidden="true" />
+                            Actualiser
+                          </button>
+                        </div>
+
+                        <form class="grid gap-4 sm:grid-cols-[repeat(auto-fit,minmax(220px,1fr))]" onSubmit=${handleApplyRange}>
+                          <label class="flex flex-col gap-2 text-sm text-slate-200">
+                            <span>Depuis</span>
+                            <input
+                              type="datetime-local"
+                              value=${draftSince}
+                              onInput=${(event) => setDraftSince(event.currentTarget.value)}
+                              class="w-full rounded-2xl border border-white/10 bg-slate-950/70 px-3 py-2 text-sm text-white shadow-inner shadow-black/20 focus:border-fuchsia-300 focus:outline-none focus:ring-1 focus:ring-fuchsia-300"
+                              required
+                            />
+                          </label>
+                          <label class="flex flex-col gap-2 text-sm text-slate-200">
+                            <span>Jusqu'à</span>
+                            <input
+                              type="datetime-local"
+                              value=${draftUntil}
+                              onInput=${(event) => setDraftUntil(event.currentTarget.value)}
+                              class="w-full rounded-2xl border border-white/10 bg-slate-950/70 px-3 py-2 text-sm text-white shadow-inner shadow-black/20 focus:border-fuchsia-300 focus:outline-none focus:ring-1 focus:ring-fuchsia-300"
+                              required
+                            />
+                          </label>
+                          <div class="flex items-end">
+                            <button
+                              type="submit"
+                              class="inline-flex w-full items-center justify-center gap-2 rounded-2xl border border-fuchsia-400/60 bg-fuchsia-500/20 px-4 py-2 text-sm font-semibold text-fuchsia-100 transition hover:bg-fuchsia-500/30 hover:text-white"
+                            >
+                              Appliquer
+                            </button>
+                          </div>
+                        </form>
+
+                        <div class="flex flex-wrap gap-3 text-xs">
+                          ${PROFILE_RANGE_PRESETS.map((preset) => {
+                            const isActive = activeDuration != null && Math.abs(activeDuration - preset.durationMs) <= 60 * 1000;
+                            const classes = [
+                              'inline-flex items-center gap-2 rounded-full border px-3 py-1.5 font-semibold transition',
+                              isActive
+                                ? 'border-fuchsia-400/60 bg-fuchsia-500/20 text-white'
+                                : 'border-white/10 bg-white/5 text-slate-200 hover:bg-white/10 hover:text-white',
+                            ].join(' ');
+                            return html`<button
+                              key=${preset.label}
+                              type="button"
+                              class=${classes}
+                              onClick=${() => handlePresetClick(preset.durationMs)}
+                            >
+                              ${preset.label}
+                              <span class="sr-only">${preset.description}</span>
+                            </button>`;
+                          })}
+                        </div>
+
+                        ${formError
+                          ? html`<p class="rounded-2xl border border-rose-400/40 bg-rose-500/10 px-4 py-2 text-xs text-rose-100">${formError}</p>`
+                          : null}
+                      </div>
+                    </section>
+
+                    ${errorMessage
+                      ? html`<div class="rounded-3xl border border-rose-400/40 bg-rose-500/10 p-4 text-sm text-rose-100 shadow-lg shadow-rose-900/30">${errorMessage}</div>`
+                      : null}
+
+                    ${isLoading && !data
+                      ? html`<div class="flex items-center gap-3 rounded-3xl border border-white/10 bg-white/5 p-4 text-sm text-slate-300">
+                          <${RefreshCcw} class="h-4 w-4 animate-spin text-indigo-200" aria-hidden="true" />
+                          Chargement du profil…
+                        </div>`
+                      : null}
+
+                    ${data
+                      ? html`
+                          <${ProfileSummaryCards} stats=${data.stats} />
+                          <${ProfileActivityTimeline}
+                            range=${activeRange}
+                            presenceSegments=${data.presenceSegments}
+                            speakingSegments=${data.speakingSegments}
+                            messageEvents=${data.messageEvents}
+                          />
+                          <${DailyBreakdown}
+                            range=${activeRange}
+                            presenceSegments=${data.presenceSegments}
+                            speakingSegments=${data.speakingSegments}
+                            messageEvents=${data.messageEvents}
+                          />
+                        `
+                      : null}
+                  </div>
+                `}
           </${Fragment}>
         `;
       };
@@ -2825,9 +3917,37 @@
 
         useEffect(() => {
           if (!window.location.hash) {
-            window.location.hash = '/';
+            window.location.hash = '#/';
+            setRoute({ name: 'home', params: {} });
           }
         }, []);
+
+        const updateProfileRoute = useCallback(
+          (userId, sinceMs, untilMs, options = {}) => {
+            if (!userId) {
+              return;
+            }
+            const sinceParam = Number.isFinite(sinceMs) ? String(Math.floor(sinceMs)) : null;
+            const untilParam = Number.isFinite(untilMs) ? String(Math.floor(untilMs)) : null;
+            const nextRoute = { name: 'profile', params: { userId, since: sinceParam, until: untilParam } };
+            const nextHash = buildProfileHash(userId, sinceMs, untilMs);
+            if (window.location.hash !== nextHash) {
+              window.location.hash = nextHash;
+            }
+            setRoute(nextRoute);
+            if (options.scrollToTop) {
+              window.scrollTo({ top: 0, behavior: 'smooth' });
+            }
+          },
+          [setRoute],
+        );
+
+        const handleProfileOpen = useCallback(
+          (userId) => {
+            updateProfileRoute(userId, null, null, { scrollToTop: true });
+          },
+          [updateProfileRoute],
+        );
 
         useEffect(() => {
           const updateRoute = () => setRoute(getRouteFromHash());
@@ -3205,7 +4325,7 @@
           if (window.location.hash !== link.hash) {
             window.location.hash = link.hash;
           } else {
-            setRoute(targetRoute);
+            setRoute({ name: targetRoute, params: {} });
           }
           setMenuOpen(false);
           window.scrollTo({ top: 0, behavior: 'smooth' });
@@ -3277,9 +4397,9 @@
                           key=${link.route}
                           href=${link.external && link.href ? link.href : link.hash}
                           onClick=${(event) => handleNavigate(event, link.route)}
-                          aria-current=${route === link.route ? 'page' : undefined}
+                          aria-current=${route.name === link.route ? 'page' : undefined}
                           class=${`text-sm font-semibold transition hover:text-white ${
-                            route === link.route ? 'text-white' : 'text-slate-300'
+                            route.name === link.route ? 'text-white' : 'text-slate-300'
                           }`}
                         >
                           ${link.label}
@@ -3313,7 +4433,7 @@
                                   href=${link.external && link.href ? link.href : link.hash}
                                   onClick=${(event) => handleNavigate(event, link.route)}
                                   class=${`rounded-full border border-white/10 bg-white/5 px-4 py-2 text-sm font-semibold transition hover:bg-white/10 hover:text-white ${
-                                    route === link.route ? 'text-white' : 'text-slate-200'
+                                    route.name === link.route ? 'text-white' : 'text-slate-200'
                                   }`}
                                 >
                                   ${link.label}
@@ -3330,12 +4450,21 @@
               <main class="flex-1 px-6 pb-16 pt-8 sm:px-10">
                 <div class="mx-auto flex max-w-5xl flex-col gap-10">
                   ${
-                    route === 'ban'
+                    route.name === 'ban'
                       ? html`<${BanPage} />`
-                      : route === 'about'
+                      : route.name === 'about'
                       ? html`<${AboutPage} />`
-                      : route === 'shop'
+                      : route.name === 'shop'
                       ? html`<${ShopPage} />`
+                      : route.name === 'profile'
+                      ? html`<${ProfilePage}
+                          params=${route.params}
+                          onNavigateHome=${() => {
+                            window.location.hash = '#/';
+                            setRoute({ name: 'home', params: {} });
+                          }}
+                          onUpdateRange=${updateProfileRoute}
+                        />`
                       : html`<${HomePage}
                           status=${status}
                           lastUpdateLabel=${lastUpdateLabel}
@@ -3347,6 +4476,7 @@
                           speakingHistory=${speakingHistory}
                           selectedWindowMinutes=${selectedWindowMinutes}
                           onWindowChange=${handleWindowChange}
+                          onViewProfile=${handleProfileOpen}
                         />`
                   }
                 </div>

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,6 +65,7 @@ const discordBridge = new DiscordAudioBridge({
   config,
   mixer,
   speakerTracker,
+  voiceActivityRepository,
 });
 
 discordBridge.login().catch((error) => {


### PR DESCRIPTION
## Summary
- collect per-user presence, speaking, and message activity in the repository and expose it via `/api/users/:userId/profile`
- fetch Discord identity details alongside the aggregated stats while keeping nullable banner URLs type-safe
- build a rich profile view with range presets, detailed metrics, unified timeline, and daily breakdown in the front-end hash route

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de68e760a4832487edca3067fddf07