### PR TITLE
Ensure talk time cards open profile view

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -924,7 +924,7 @@
         `;
       };
 
-      const RealTimeTalkChart = ({ history, speakers, now, selectedWindowMinutes, onWindowChange }) => {
+      const RealTimeTalkChart = ({ history, speakers, now, selectedWindowMinutes, onWindowChange, onViewProfile }) => {
         const windowMs = selectedWindowMinutes * 60 * 1000;
 
         const speakerIndex = useMemo(() => {
@@ -2644,12 +2644,13 @@
 
         <${DailyActivityChart} history=${speakingHistory} now=${now} />
 
-        <${RealTimeTalkChart}
+          <${RealTimeTalkChart}
           history=${speakingHistory}
           speakers=${speakers}
           now=${now}
             selectedWindowMinutes=${selectedWindowMinutes}
             onWindowChange=${onWindowChange}
+            onViewProfile=${onViewProfile}
           />
 
           <${AnonymousBooth} slot=${anonymousSlot} now=${now} />


### PR DESCRIPTION
## Summary
- pass the profile navigation handler down to the real-time talk chart
- ensure the cumulative talk time cards and top voice badge navigate to the user profile

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dea8821dcc8324b5a96d5dce2d7d8c