### PR TITLE
Make member cards clickable on members page

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2318,10 +2318,6 @@
                   </p>
                 </div>
                 <div class="flex flex-col gap-3 text-xs text-slate-200 sm:flex-row sm:items-center">
-                  <span class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-2">
-                    <${Users} class="h-4 w-4" aria-hidden="true" />
-                    ${members.length} affichés
-                  </span>
                   <button
                     type="button"
                     class=${[
@@ -2423,7 +2419,16 @@
 
                       return html`<article
                         key=${id || displayName}
-                        class="flex h-full flex-col gap-4 rounded-3xl border border-white/10 bg-white/5 p-5 shadow-lg shadow-slate-950/40 backdrop-blur"
+                        class="flex h-full cursor-pointer flex-col gap-4 rounded-3xl border border-white/10 bg-white/5 p-5 shadow-lg shadow-slate-950/40 backdrop-blur transition hover:border-white/20 hover:bg-white/10"
+                        role="button"
+                        tabIndex="0"
+                        onClick=${() => handleOpenProfile(id)}
+                        onKeyDown=${(event) => {
+                          if (event.key === 'Enter' || event.key === ' ') {
+                            event.preventDefault();
+                            handleOpenProfile(id);
+                          }
+                        }}
                       >
                         <div class="flex items-center gap-4">
                           <${MemberAvatar} member=${member} />
@@ -2458,16 +2463,7 @@
                               : null}
                           </div>
                         </div>
-                        <div class="mt-auto flex items-center justify-between gap-3">
-                          <button
-                            type="button"
-                            class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-200 transition hover:bg-white/10 hover:text-white"
-                            onClick=${() => handleOpenProfile(id)}
-                          >
-                            Voir le profil
-                            <${ArrowRight} class="h-3.5 w-3.5" aria-hidden="true" />
-                          </button>
-                        </div>
+                        <div class="mt-auto"></div>
                       </article>`;
                     })}
                   </div>`


### PR DESCRIPTION
## Summary
- remove the "24 affichés" pill from the members page header
- make the member cards clickable with keyboard support to open the profile
- remove the dedicated "Voir le profil" button now that the card itself is interactive

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68deaeb7967083249fc7dda9876e3a8c