### PR TITLE
Use text_messages for member activity and surface recent messages

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2148,6 +2148,43 @@
         </div>`;
       };
 
+      const MemberRecentMessages = ({ messages }) => {
+        const list = Array.isArray(messages) ? messages.slice(0, 3) : [];
+
+        if (list.length === 0) {
+          return html`<div class="rounded-2xl border border-white/5 bg-white/5 px-3 py-2 text-[11px] text-slate-400">
+            Aucun message récent
+          </div>`;
+        }
+
+        return html`<div class="space-y-2 rounded-2xl border border-white/10 bg-slate-950/40 px-3 py-2">
+          <p class="text-[10px] font-semibold uppercase tracking-[0.25em] text-slate-300">Messages récents</p>
+          <ul class="space-y-2">
+            ${list.map((message) => {
+              const timestamp =
+                message?.timestamp instanceof Date
+                  ? message.timestamp.getTime()
+                  : typeof message?.timestamp === 'string'
+                  ? Date.parse(message.timestamp)
+                  : Number.isFinite(message?.timestampMs)
+                  ? message.timestampMs
+                  : NaN;
+              const formattedTime = Number.isFinite(timestamp)
+                ? formatDateTimeLabel(timestamp, { includeSeconds: false })
+                : 'Date inconnue';
+              const content = typeof message?.content === 'string' && message.content.trim().length > 0
+                ? message.content.trim()
+                : '—';
+
+              return html`<li key=${message?.messageId || formattedTime} class="space-y-1 text-[11px] text-slate-200">
+                <p class="break-words text-slate-100">${content}</p>
+                <p class="text-[10px] uppercase tracking-[0.25em] text-slate-400">${formattedTime}</p>
+              </li>`;
+            })}
+          </ul>
+        </div>`;
+      };
+
       const MEMBERS_PAGE_SIZE = 24;
 
       const MembersPage = ({ onViewProfile }) => {
@@ -2416,6 +2453,7 @@
                         : [];
                       const remainingRoles = Array.isArray(member?.roles) ? Math.max(member.roles.length - roleList.length, 0) : 0;
                       const isBot = Boolean(member?.isBot);
+                      const recentMessages = Array.isArray(member?.recentMessages) ? member.recentMessages : [];
 
                       return html`<article
                         key=${id || displayName}
@@ -2462,6 +2500,7 @@
                                 </span>`
                               : null}
                           </div>
+                          <${MemberRecentMessages} messages=${recentMessages} />
                         </div>
                         <div class="mt-auto"></div>
                       </article>`;

--- a/src/discord/DiscordAudioBridge.ts
+++ b/src/discord/DiscordAudioBridge.ts
@@ -195,6 +195,7 @@ export default class DiscordAudioBridge {
           userId: message.author.id,
           guildId: message.guildId ?? null,
           channelId: message.channelId,
+          content: message.content ?? null,
           timestamp: createdAt,
         })
         .catch((error) => {


### PR DESCRIPTION
## Summary
- switch backend message persistence and analytics from `message_activity` to `text_messages`
- expose recent text messages in the members API and display them in the members page
- enrich user profile analytics with message content information

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68deb0dd49b08324bea2d2e384b9dbf4