### PR TITLE
Fix activity chart loading state prop

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -747,7 +747,7 @@
         `;
       };
 
-      const DailyActivityChart = ({ history, now }) => {
+      const DailyActivityChart = ({ history, now, isHistoryLoading }) => {
         const scrollContainerRef = useRef(null);
         const currentBinRef = useRef(null);
         const setCurrentBinRef = useCallback((element) => {
@@ -3057,6 +3057,7 @@
         now,
         anonymousSlot,
         speakingHistory,
+        isHistoryLoading,
         selectedWindowMinutes,
         onWindowChange,
         onViewProfile,
@@ -3112,7 +3113,11 @@
           <${AudioPlayer} streamInfo=${streamInfo} audioKey=${audioKey} status=${status} />
         </section>
 
-        <${DailyActivityChart} history=${speakingHistory} now=${now} />
+        <${DailyActivityChart}
+          history=${speakingHistory}
+          now=${now}
+          isHistoryLoading=${isHistoryLoading}
+        />
 
           <${RealTimeTalkChart}
           history=${speakingHistory}
@@ -5157,6 +5162,7 @@
                           now=${now}
                           anonymousSlot=${anonymousSlot}
                           speakingHistory=${speakingHistory}
+                          isHistoryLoading=${isHistoryLoading}
                           selectedWindowMinutes=${selectedWindowMinutes}
                           onWindowChange=${handleWindowChange}
                           onViewProfile=${handleProfileOpen}


### PR DESCRIPTION
## Summary
- pass the history loading flag from the app into the home page and daily activity chart
- prevent the DailyActivityChart component from referencing an undefined loading variable

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dece1575708324abf7d10b73fc3df0