### PR TITLE
Add hourly leaderboard trend tracking

### DIFF
--- a/public/classements.html
+++ b/public/classements.html
@@ -527,11 +527,61 @@
           ? `<p class="mt-1 text-xs font-medium text-slate-400/80">${normalizedUsername}</p>`
           : '';
 
+        const positionTrend = leader?.positionTrend ?? null;
+        const movement = positionTrend?.movement ?? 'same';
+        const delta = Number.isFinite(positionTrend?.delta) ? Number(positionTrend.delta) : null;
+
+        const { movementIcon, movementLabel, movementClass, movementDelta } = (() => {
+          switch (movement) {
+            case 'up':
+              return {
+                movementIcon: '↑',
+                movementLabel: 'Monte',
+                movementClass: 'text-emerald-300',
+                movementDelta: delta !== null && delta !== 0 ? `+${delta}` : '+0',
+              };
+            case 'down':
+              return {
+                movementIcon: '↓',
+                movementLabel: 'Descend',
+                movementClass: 'text-rose-300',
+                movementDelta: delta !== null && delta !== 0 ? `${delta}` : '0',
+              };
+            case 'new':
+              return {
+                movementIcon: '★',
+                movementLabel: 'Nouveau',
+                movementClass: 'text-amber-300',
+                movementDelta: '—',
+              };
+            default:
+              return {
+                movementIcon: '→',
+                movementLabel: 'Stable',
+                movementClass: 'text-slate-300',
+                movementDelta: '0',
+              };
+          }
+        })();
+
+        const trendBadge = `
+          <span class="flex flex-col text-[0.65rem] font-semibold leading-tight ${movementClass}">
+            <span class="flex items-center gap-1">
+              <span aria-hidden="true">${movementIcon}</span>
+              <span>${movementDelta}</span>
+            </span>
+            <span class="uppercase tracking-[0.2em] text-[0.55rem] text-slate-400/70">${movementLabel}</span>
+          </span>
+        `;
+
         container.innerHTML = `
           <div class="absolute inset-0 bg-gradient-to-r ${rank <= 3 ? accent : 'from-transparent to-transparent'} opacity-[0.22]"></div>
           <div class="relative flex flex-col gap-6 p-6 sm:flex-row sm:items-center sm:justify-between">
             <div class="flex flex-1 items-center gap-5">
-              <span class="flex h-12 w-12 items-center justify-center rounded-2xl bg-white/10 text-lg font-extrabold text-white">${pad(rank)}</span>
+              <div class="flex items-center gap-3">
+                <span class="flex h-12 w-12 items-center justify-center rounded-2xl bg-white/10 text-lg font-extrabold text-white">${pad(rank)}</span>
+                ${trendBadge}
+              </div>
               <div>
                 <h3 class="text-lg font-semibold text-white">${leader.displayName}</h3>
                 ${usernameMarkup}
@@ -589,15 +639,39 @@
         });
       };
 
-      const displayMeta = (count) => {
-        const now = new Date();
+      const parseDate = (value) => {
+        if (!value) {
+          return null;
+        }
+        const candidate = new Date(value);
+        return Number.isNaN(candidate.getTime()) ? null : candidate;
+      };
+
+      const displayMeta = (count, snapshot) => {
+        const bucketDate = parseDate(snapshot?.bucketStart) ?? new Date();
         const formatted = new Intl.DateTimeFormat('fr-FR', {
           hour: '2-digit',
           minute: '2-digit',
           day: '2-digit',
           month: 'long',
-        }).format(now);
-        metaElement.textContent = `${count} profils · Mise à jour ${formatted}`;
+        }).format(bucketDate);
+
+        let comparisonSegment = '';
+        const comparedDate = parseDate(snapshot?.comparedTo);
+        if (comparedDate) {
+          const diffMs = bucketDate.getTime() - comparedDate.getTime();
+          const diffHours = diffMs / 3_600_000;
+          if (Number.isFinite(diffHours)) {
+            const formatter = new Intl.RelativeTimeFormat('fr-FR', { numeric: 'auto' });
+            const rounded = Math.round(diffHours);
+            comparisonSegment =
+              rounded === 0
+                ? ' · Variations sur l’heure en cours'
+                : ` · Variations ${formatter.format(-rounded, 'hour')}`;
+          }
+        }
+
+        metaElement.textContent = `${count} profils · Mise à jour ${formatted}${comparisonSegment}`;
       };
 
       let currentRequestController = null;
@@ -634,8 +708,9 @@
             return;
           }
           const leaders = Array.isArray(payload?.leaders) ? payload.leaders : [];
+          const snapshot = payload?.snapshot ?? null;
           renderLeaderboard(leaders);
-          displayMeta(leaders.length);
+          displayMeta(leaders.length, snapshot);
           hasLoadedOnce = true;
         } catch (error) {
           if (controller.signal.aborted) {
@@ -643,7 +718,7 @@
           }
           console.error(error);
           renderErrorState();
-          displayMeta(0);
+          displayMeta(0, null);
         }
         finally {
           if (currentRequestController === controller) {

--- a/src/services/HypeLeaderboardService.ts
+++ b/src/services/HypeLeaderboardService.ts
@@ -1,0 +1,239 @@
+import type VoiceActivityRepository from './VoiceActivityRepository';
+import type {
+  HypeLeaderEntry,
+  HypeLeaderboardQueryOptions,
+  HypeLeaderboardSnapshotEntry,
+  HypeLeaderboardSnapshotOptions,
+  HypeLeaderboardSortBy,
+  HypeLeaderboardSortOrder,
+} from './VoiceActivityRepository';
+
+export type LeaderboardPositionMovement = 'up' | 'down' | 'same' | 'new';
+
+export interface LeaderboardPositionTrend {
+  rank: number;
+  previousRank: number | null;
+  delta: number | null;
+  movement: LeaderboardPositionMovement;
+  comparedAt: Date | null;
+}
+
+export interface HypeLeaderWithTrend extends HypeLeaderEntry {
+  rank: number;
+  positionTrend: LeaderboardPositionTrend;
+}
+
+export interface HypeLeaderboardResult {
+  leaders: HypeLeaderWithTrend[];
+  snapshot: {
+    bucketStart: Date;
+    comparedTo: Date | null;
+  };
+}
+
+export interface NormalizedHypeLeaderboardQueryOptions {
+  limit: number;
+  search: string | null;
+  sortBy: HypeLeaderboardSortBy;
+  sortOrder: HypeLeaderboardSortOrder;
+  periodDays: number | null;
+}
+
+interface HypeLeaderboardServiceOptions {
+  repository: VoiceActivityRepository;
+  snapshotIntervalMs?: number;
+}
+
+export default class HypeLeaderboardService {
+  private readonly repository: VoiceActivityRepository;
+
+  private readonly snapshotIntervalMs: number;
+
+  private readonly defaultOptions: NormalizedHypeLeaderboardQueryOptions = {
+    limit: 100,
+    search: null,
+    sortBy: 'schScoreNorm',
+    sortOrder: 'desc',
+    periodDays: null,
+  };
+
+  constructor({ repository, snapshotIntervalMs = 60 * 60 * 1000 }: HypeLeaderboardServiceOptions) {
+    this.repository = repository;
+    this.snapshotIntervalMs = Math.max(60_000, snapshotIntervalMs);
+  }
+
+  public getDefaultOptions(): NormalizedHypeLeaderboardQueryOptions {
+    return { ...this.defaultOptions };
+  }
+
+  public normalizeOptions(
+    options?: HypeLeaderboardQueryOptions | NormalizedHypeLeaderboardQueryOptions | null,
+  ): NormalizedHypeLeaderboardQueryOptions {
+    const limit = (() => {
+      if (!options || !Number.isFinite(options.limit)) {
+        return this.defaultOptions.limit;
+      }
+      const normalized = Math.max(1, Math.floor(Number(options.limit)));
+      return Math.min(normalized, 200);
+    })();
+
+    const search = (() => {
+      const candidate = options?.search;
+      if (typeof candidate !== 'string') {
+        return this.defaultOptions.search;
+      }
+      const trimmed = candidate.trim();
+      return trimmed.length > 0 ? trimmed : this.defaultOptions.search;
+    })();
+
+    const sortBy: HypeLeaderboardSortBy = (() => {
+      const candidate = options?.sortBy;
+      const allowed: HypeLeaderboardQueryOptions['sortBy'][] = [
+        'schScoreNorm',
+        'schRaw',
+        'arrivalEffect',
+        'departureEffect',
+        'retentionMinutes',
+        'activityScore',
+        'sessions',
+        'displayName',
+      ];
+      if (candidate && allowed.includes(candidate)) {
+        return candidate as HypeLeaderboardSortBy;
+      }
+      return this.defaultOptions.sortBy;
+    })();
+
+    const sortOrder: HypeLeaderboardSortOrder = options?.sortOrder === 'asc' ? 'asc' : 'desc';
+
+    const periodDays = (() => {
+      if (!options || !Number.isFinite(options.periodDays)) {
+        return this.defaultOptions.periodDays;
+      }
+      const normalized = Math.max(1, Math.floor(Number(options.periodDays)));
+      return Math.min(normalized, 365);
+    })();
+
+    return { limit, search, sortBy, sortOrder, periodDays };
+  }
+
+  public buildCacheKey(options: NormalizedHypeLeaderboardQueryOptions): string {
+    const parts = [
+      `limit:${options.limit}`,
+      `search:${options.search ?? ''}`,
+      `sortBy:${options.sortBy}`,
+      `sortOrder:${options.sortOrder}`,
+      `period:${options.periodDays ?? 'all'}`,
+    ];
+    return parts.join('|');
+  }
+
+  public async getLeaderboardWithTrends(
+    options: NormalizedHypeLeaderboardQueryOptions,
+    now: Date = new Date(),
+  ): Promise<HypeLeaderboardResult> {
+    const leaders = await this.repository.listHypeLeaders(options);
+    const ranked = leaders.map<HypeLeaderWithTrend>((leader, index) => ({
+      ...leader,
+      rank: index + 1,
+      positionTrend: {
+        rank: index + 1,
+        previousRank: null,
+        delta: null,
+        movement: 'new',
+        comparedAt: null,
+      },
+    }));
+
+    const bucketStart = this.getBucketStart(now);
+    const previousBucket = new Date(bucketStart.getTime() - this.snapshotIntervalMs);
+    const optionsHash = this.buildCacheKey(options);
+
+    const snapshotEntries: HypeLeaderboardSnapshotEntry[] = ranked.map((entry) => ({
+      userId: entry.userId,
+      rank: entry.rank,
+      sessions: entry.sessions,
+      activityScore: entry.activityScore,
+      schScoreNorm: entry.schScoreNorm,
+    }));
+
+    await this.repository.saveHypeLeaderboardSnapshot({
+      bucketStart,
+      optionsHash,
+      options: this.toSnapshotOptions(options),
+      leaders: snapshotEntries,
+    });
+
+    const comparisonSnapshot =
+      (await this.repository.loadHypeLeaderboardSnapshot({
+        bucketStart: previousBucket,
+        optionsHash,
+      })) ||
+      (await this.repository.loadLatestHypeLeaderboardSnapshot({
+        optionsHash,
+        before: bucketStart,
+      }));
+
+    const previousRankMap = new Map<string, number>();
+    const comparedAt = comparisonSnapshot?.bucketStart ?? null;
+    for (const leader of comparisonSnapshot?.leaders ?? []) {
+      if (leader && typeof leader.userId === 'string') {
+        previousRankMap.set(leader.userId, Number(leader.rank));
+      }
+    }
+
+    for (const entry of ranked) {
+      const previousRank = previousRankMap.has(entry.userId)
+        ? Number(previousRankMap.get(entry.userId))
+        : null;
+      const delta = previousRank === null ? null : previousRank - entry.rank;
+      let movement: LeaderboardPositionMovement = 'new';
+      if (previousRank !== null) {
+        if (delta === null || delta === 0) {
+          movement = 'same';
+        } else if (delta > 0) {
+          movement = 'up';
+        } else {
+          movement = 'down';
+        }
+      }
+
+      entry.positionTrend = {
+        rank: entry.rank,
+        previousRank,
+        delta,
+        movement,
+        comparedAt,
+      };
+    }
+
+    return {
+      leaders: ranked,
+      snapshot: {
+        bucketStart,
+        comparedTo: comparedAt,
+      },
+    };
+  }
+
+  private getBucketStart(date: Date): Date {
+    const ms = date.getTime();
+    if (!Number.isFinite(ms)) {
+      return this.getBucketStart(new Date());
+    }
+    const bucket = Math.floor(ms / this.snapshotIntervalMs) * this.snapshotIntervalMs;
+    return new Date(bucket);
+  }
+
+  private toSnapshotOptions(
+    options: NormalizedHypeLeaderboardQueryOptions,
+  ): HypeLeaderboardSnapshotOptions {
+    return {
+      limit: options.limit,
+      search: options.search,
+      sortBy: options.sortBy,
+      sortOrder: options.sortOrder,
+      periodDays: options.periodDays,
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- add a dedicated hype leaderboard service that snapshots rankings and computes position trends
- extend the voice activity repository and API endpoint to persist hourly snapshots and expose trend metadata
- update the leaderboard page to render movement indicators and refreshed metadata

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ded33709b08324b64e7d07d61a56e0