### PR TITLE
Fix member message lookup for the members page

### DIFF
--- a/src/services/VoiceActivityRepository.ts
+++ b/src/services/VoiceActivityRepository.ts
@@ -904,7 +904,7 @@ export default class VoiceActivityRepository {
                         timestamp,
                         ROW_NUMBER() OVER (PARTITION BY user_id ORDER BY timestamp DESC) AS rn
                    FROM text_messages
-                  WHERE user_id = ANY($1::text[])
+                  WHERE user_id::text = ANY($1::text[])
                 ) ranked
           WHERE rn <= $2
           ORDER BY user_id, timestamp DESC`,


### PR DESCRIPTION
## Summary
- ensure the recent member message query casts numeric user ids to text before filtering so recent messages appear on member cards

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dee3e47450832487e30d616ec21f5f