### PR TITLE
Rename moderation menu label

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2549,7 +2549,7 @@
           href: '/classements',
           external: true,
         },
-        { label: 'Actions de modération', route: 'ban', hash: '#/bannir' },
+        { label: 'Modération dans le menu', route: 'ban', hash: '#/bannir' },
         { label: 'À propos', route: 'about', hash: '#/about' },
       ];
 
@@ -4500,7 +4500,7 @@
         <${Fragment}>
           <section class="space-y-6 rounded-3xl border border-white/10 bg-white/5 px-8 py-12 shadow-xl shadow-slate-950/40 backdrop-blur-xl">
             <p class="text-xs uppercase tracking-[0.35em] text-slate-300">Modération</p>
-            <h1 class="text-4xl font-bold tracking-tight text-white sm:text-5xl">Actions de modération</h1>
+            <h1 class="text-4xl font-bold tracking-tight text-white sm:text-5xl">Modération dans le menu</h1>
             <p class="text-base leading-relaxed text-slate-200">
               Besoin d’écarter un fauteur de trouble sans casser l’ambiance ? Choisis la sanction la plus adaptée.
               Mute express ou bannissement encadré : l’équipe Libre Antenne se charge de l’exécution, du suivi et


### PR DESCRIPTION
## Summary
- rename the moderation navigation label to "Modération dans le menu"
- update the moderation page heading to match the new label

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dee7558b9c8324bb3001fd5c370b0a