### PR TITLE
Set hype leaderboard default period to 30 days

### DIFF
--- a/public/classements.html
+++ b/public/classements.html
@@ -274,9 +274,9 @@
               id="leaderboard-period"
               class="w-full rounded-2xl border border-white/10 bg-slate-900/60 px-4 py-2 text-sm text-white transition focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/40"
             >
-              <option value="all" selected>Toujours</option>
+              <option value="all">Toujours</option>
               <option value="7">7 jours</option>
-              <option value="30">30 jours</option>
+              <option value="30" selected>30 jours</option>
               <option value="90">90 jours</option>
               <option value="365">365 jours</option>
             </select>
@@ -352,7 +352,7 @@
         search: searchInput?.value?.trim?.() ?? '',
         sortBy: sortBySelect?.value ?? 'schScoreNorm',
         sortOrder: 'desc',
-        period: periodSelect?.value ?? 'all',
+        period: periodSelect?.value ?? '30',
       };
 
       const sortableColumns = new Set([
@@ -365,7 +365,7 @@
 
       const periodOptions = (() => {
         if (!periodSelect) {
-          return new Set(['all']);
+          return new Set(['30', 'all']);
         }
         return new Set(Array.from(periodSelect.options).map((option) => option.value || 'all'));
       })();
@@ -428,7 +428,7 @@
           } else if (periodOptions.has(normalized)) {
             state.period = normalized;
           } else {
-            state.period = 'all';
+            state.period = '30';
           }
         }
 
@@ -442,7 +442,7 @@
 
         if (periodSelect) {
           if (!periodOptions.has(state.period)) {
-            state.period = 'all';
+            state.period = '30';
           }
           periodSelect.value = state.period;
         }
@@ -461,7 +461,7 @@
         if (state.search && state.search.length > 0) {
           params.set('search', state.search);
         }
-        if (state.period && state.period !== 'all') {
+        if (state.period && state.period.length > 0) {
           params.set('period', state.period);
         }
         return params;

--- a/src/http/AppServer.ts
+++ b/src/http/AppServer.ts
@@ -757,19 +757,23 @@ export default class AppServer {
     return parsed;
   }
 
-  private parsePeriodParam(value: string | null): number | null {
-    if (!value) {
-      return null;
+  private parsePeriodParam(value: string | null): number | null | undefined {
+    if (value === null) {
+      return undefined;
     }
 
     const normalized = value.trim().toLowerCase();
-    if (normalized.length === 0 || normalized === 'all' || normalized === 'tout') {
+    if (normalized.length === 0) {
+      return undefined;
+    }
+
+    if (normalized === 'all' || normalized === 'tout') {
       return null;
     }
 
     const parsed = Number.parseInt(normalized, 10);
     if (!Number.isFinite(parsed) || parsed <= 0) {
-      return null;
+      return undefined;
     }
 
     return parsed;
@@ -789,7 +793,8 @@ export default class AppServer {
         ? (normalized as HypeLeaderboardSortOrder)
         : null;
     })();
-    const periodParam = this.parsePeriodParam(this.extractQueryParam(req.query.period));
+    const rawPeriodParam = this.extractQueryParam(req.query.period);
+    const periodParam = this.parsePeriodParam(rawPeriodParam);
 
     const options: HypeLeaderboardQueryOptions = {
       limit,
@@ -827,8 +832,11 @@ export default class AppServer {
     const fallbackSortOrder: HypeLeaderboardSortOrder = options.sortOrder === 'asc' ? 'asc' : 'desc';
 
     const fallbackPeriodDays = (() => {
-      if (!Number.isFinite(options.periodDays)) {
+      if (options.periodDays === null) {
         return null;
+      }
+      if (!Number.isFinite(options.periodDays)) {
+        return 30;
       }
       const normalized = Math.max(1, Math.floor(Number(options.periodDays)));
       return Math.min(normalized, 365);

--- a/src/services/HypeLeaderboardService.ts
+++ b/src/services/HypeLeaderboardService.ts
@@ -54,7 +54,7 @@ export default class HypeLeaderboardService {
     search: null,
     sortBy: 'schScoreNorm',
     sortOrder: 'desc',
-    periodDays: null,
+    periodDays: 30,
   };
 
   constructor({ repository, snapshotIntervalMs = 60 * 60 * 1000 }: HypeLeaderboardServiceOptions) {
@@ -107,7 +107,13 @@ export default class HypeLeaderboardService {
     const sortOrder: HypeLeaderboardSortOrder = options?.sortOrder === 'asc' ? 'asc' : 'desc';
 
     const periodDays = (() => {
-      if (!options || !Number.isFinite(options.periodDays)) {
+      if (!options) {
+        return this.defaultOptions.periodDays;
+      }
+      if (options.periodDays === null) {
+        return null;
+      }
+      if (!Number.isFinite(options.periodDays)) {
         return this.defaultOptions.periodDays;
       }
       const normalized = Math.max(1, Math.floor(Number(options.periodDays)));


### PR DESCRIPTION
## Summary
- set the hype leaderboard default period to 30 days on both the API and static leaderboard page
- keep support for the "always" option by distinguishing absent and explicit period filters

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68deeeb8baf8832497efc7c768b649e4