### PR TITLE
Set default profile period to 30 days

### DIFF
--- a/src/http/AppServer.ts
+++ b/src/http/AppServer.ts
@@ -453,7 +453,7 @@ export default class AppServer {
       const now = new Date();
       const untilCandidate = this.parseTimestamp(untilParam) ?? now;
       const sinceCandidate = this.parseTimestamp(sinceParam)
-        ?? new Date(untilCandidate.getTime() - 24 * 60 * 60 * 1000);
+        ?? new Date(untilCandidate.getTime() - 30 * 24 * 60 * 60 * 1000);
 
       if (Number.isNaN(sinceCandidate.getTime()) || Number.isNaN(untilCandidate.getTime())) {
         res


### PR DESCRIPTION
## Summary
- update the profile analytics endpoint to default to a 30-day range when no dates are provided

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68def8be68008324a293f181e67992f2