### PR TITLE
Enhance homepage can lighting and effects

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3105,16 +3105,24 @@
           container.style.touchAction = 'none';
           container.style.cursor = 'grab';
 
-          const ambientLight = new THREE.AmbientLight(0xffffff, 0.85);
+          const ambientLight = new THREE.AmbientLight(0xffffff, 1.1);
           scene.add(ambientLight);
 
-          const keyLight = new THREE.DirectionalLight(0xffffff, 0.9);
-          keyLight.position.set(3, 4, 5);
+          const keyLight = new THREE.DirectionalLight(0xf8fafc, 1.35);
+          keyLight.position.set(3.5, 4.5, 5);
           scene.add(keyLight);
 
-          const rimLight = new THREE.PointLight(0x6366f1, 0.7);
+          const rimLight = new THREE.PointLight(0x6366f1, 1.2, 8, 2);
           rimLight.position.set(-4, -3, -2);
           scene.add(rimLight);
+
+          const fillLight = new THREE.PointLight(0x38bdf8, 1.1, 10, 2);
+          fillLight.position.set(-1.5, 1.8, 3.5);
+          scene.add(fillLight);
+
+          const glowLight = new THREE.PointLight(0xa855f7, 1.4, 6, 2.5);
+          glowLight.position.set(0, 0.4, 2.8);
+          scene.add(glowLight);
 
           const canGroup = new THREE.Group();
           scene.add(canGroup);
@@ -3130,13 +3138,16 @@
           const sideMaterial = new THREE.MeshStandardMaterial({
             map: canTexture || undefined,
             color: canTexture ? 0xffffff : 0x1e293b,
-            metalness: 0.55,
-            roughness: 0.33,
+            emissive: new THREE.Color(0x1e3a8a).multiplyScalar(0.18),
+            metalness: 0.72,
+            roughness: 0.22,
+            envMapIntensity: 1.2,
           });
           const topMaterial = new THREE.MeshStandardMaterial({
             color: 0xe2e8f0,
             metalness: 0.95,
-            roughness: 0.25,
+            roughness: 0.18,
+            emissive: new THREE.Color(0x312e81).multiplyScalar(0.22),
           });
           const canMesh = new THREE.Mesh(canGeometry, [sideMaterial, topMaterial, topMaterial]);
           canGroup.add(canMesh);
@@ -3165,6 +3176,60 @@
           topCap.position.y = 1.01;
           topCap.rotation.x = -Math.PI / 2;
           canGroup.add(topCap);
+
+          const waveGroup = new THREE.Group();
+          waveGroup.position.y = -0.15;
+          scene.add(waveGroup);
+
+          const waveMeshes = [];
+          const waveMaterials = [];
+          const waveGeometries = [];
+          for (let index = 0; index < 3; index += 1) {
+            const innerRadius = 0.75 + index * 0.03;
+            const ringGeometry = new THREE.RingGeometry(innerRadius, innerRadius + 0.02, 128);
+            const ringMaterial = new THREE.MeshBasicMaterial({
+              color: index % 2 === 0 ? 0x60a5fa : 0xa855f7,
+              transparent: true,
+              opacity: 0,
+              blending: THREE.AdditiveBlending,
+              side: THREE.DoubleSide,
+              depthWrite: false,
+            });
+            const ringMesh = new THREE.Mesh(ringGeometry, ringMaterial);
+            ringMesh.rotation.x = Math.PI / 2;
+            waveGroup.add(ringMesh);
+            waveMeshes.push(ringMesh);
+            waveMaterials.push(ringMaterial);
+            waveGeometries.push(ringGeometry);
+          }
+
+          const particleCount = 180;
+          const particleGeometry = new THREE.BufferGeometry();
+          const particlePositions = new Float32Array(particleCount * 3);
+          const particleSpeeds = new Float32Array(particleCount);
+          for (let index = 0; index < particleCount; index += 1) {
+            const angle = Math.random() * Math.PI * 2;
+            const radius = 0.35 + Math.random() * 0.6;
+            const height = (Math.random() - 0.3) * 1.2;
+            particlePositions[index * 3] = Math.cos(angle) * radius;
+            particlePositions[index * 3 + 1] = height;
+            particlePositions[index * 3 + 2] = Math.sin(angle) * radius;
+            particleSpeeds[index] = 0.00035 + Math.random() * 0.00055;
+          }
+          particleGeometry.setAttribute('position', new THREE.BufferAttribute(particlePositions, 3));
+
+          const particleMaterial = new THREE.PointsMaterial({
+            color: 0x7c3aed,
+            size: 0.06,
+            transparent: true,
+            opacity: 0.85,
+            blending: THREE.AdditiveBlending,
+            depthWrite: false,
+            sizeAttenuation: true,
+          });
+          const particles = new THREE.Points(particleGeometry, particleMaterial);
+          particles.position.y = -0.2;
+          scene.add(particles);
 
           const defaultRotation = { x: 0.35, y: -0.4 };
           const targetRotation = { ...defaultRotation };
@@ -3195,6 +3260,7 @@
           window.addEventListener('resize', handleResize);
 
           let animationFrameId = 0;
+          const startTime = performance.now();
           const animate = (time) => {
             animationFrameId = requestAnimationFrame(animate);
             currentRotation.x += (targetRotation.x - currentRotation.x) * 0.075;
@@ -3202,6 +3268,35 @@
             canGroup.rotation.x = currentRotation.x + Math.sin(time * 0.00045) * 0.05;
             canGroup.rotation.y = currentRotation.y + Math.cos(time * 0.00035) * 0.04;
             canGroup.position.y = Math.sin(time * 0.0006) * 0.05;
+
+            const elapsed = time - startTime;
+            waveMeshes.forEach((mesh, index) => {
+              const material = waveMaterials[index];
+              const progress = ((elapsed / 1800 + index / waveMeshes.length) % 1 + 1) % 1;
+              const scale = 1 + progress * 1.85;
+              mesh.scale.setScalar(scale);
+              material.opacity = 0.65 * (1 - progress);
+            });
+
+            const positions = particleGeometry.attributes.position.array;
+            for (let index = 0; index < particleCount; index += 1) {
+              const yIndex = index * 3 + 1;
+              positions[yIndex] += particleSpeeds[index] * Math.max(1, 1 + Math.sin(time * 0.0015));
+              if (positions[yIndex] > 1.6) {
+                positions[yIndex] = -0.8 + Math.random() * 0.4;
+                const angle = Math.random() * Math.PI * 2;
+                const radius = 0.35 + Math.random() * 0.6;
+                positions[index * 3] = Math.cos(angle) * radius;
+                positions[index * 3 + 2] = Math.sin(angle) * radius;
+              }
+            }
+            particleGeometry.attributes.position.needsUpdate = true;
+
+            const pulse = 0.9 + Math.sin(time * 0.0012) * 0.25;
+            rimLight.intensity = 0.9 * pulse;
+            fillLight.intensity = 0.75 * pulse + 0.55;
+            glowLight.intensity = 1.1 * pulse;
+
             renderer.render(scene, camera);
           };
           animationFrameId = requestAnimationFrame(animate);
@@ -3217,6 +3312,10 @@
             topMaterial.dispose();
             lipMaterial.dispose();
             topCapMaterial.dispose();
+            waveGeometries.forEach((geometry) => geometry.dispose());
+            waveMaterials.forEach((material) => material.dispose());
+            particleGeometry.dispose();
+            particleMaterial.dispose();
             canTexture?.dispose?.();
             renderer.dispose();
             container.style.touchAction = '';


### PR DESCRIPTION
## Summary
- intensify the Three.js lighting setup around the homepage can to make it appear brighter and more reflective
- add animated wave rings and particle emitters so the can looks like it is radiating energy

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68def9c395108324af3ba98acde374d3