### PR TITLE
Fix leaderboard period filter SQL expression

### DIFF
--- a/src/services/VoiceActivityRepository.ts
+++ b/src/services/VoiceActivityRepository.ts
@@ -1080,7 +1080,7 @@ export default class VoiceActivityRepository {
     }
 
     const sinceExpression = sinceDaysParamIndex
-      ? `CURRENT_TIMESTAMP - $${sinceDaysParamIndex} * INTERVAL '1 day'`
+      ? `CURRENT_TIMESTAMP - make_interval(days => $${sinceDaysParamIndex}::int)`
       : null;
 
     const presenceWhereClause = (alias: string) => {


### PR DESCRIPTION
## Summary
- ensure the hype leaderboard period filter builds a valid PostgreSQL expression using make_interval

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68defa8afebc83249721d967fde870b2