### PR TITLE
Set profile activity filter default to 30 days

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -346,7 +346,7 @@
       const HOUR_MS = 60 * MINUTE_MS;
       const DAY_MS = 24 * HOUR_MS;
       const FALLBACK_SEGMENT_MS = 1000;
-      const DEFAULT_PROFILE_RANGE_MS = 24 * HOUR_MS;
+      const DEFAULT_PROFILE_RANGE_MS = 30 * DAY_MS;
 
       const sanitizeProfile = (raw = {}) => {
         const displayName = typeof raw.displayName === 'string' && raw.displayName.trim().length > 0 ? raw.displayName.trim() : null;


### PR DESCRIPTION
## Summary
- set the default activity filter on member profile pages to cover the last 30 days

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68defd3b942c83248de59ddc330136d0