### PR TITLE
Fix Ban page runtime errors from missing imports

### DIFF
--- a/public/scripts/components/index.js
+++ b/public/scripts/components/index.js
@@ -2360,4 +2360,5 @@ export {
   DailyBreakdown,
   ProfileVoiceTranscriptionsCard,
   ProfileMessagesCard,
+  MODERATION_SERVICES,
 };

--- a/public/scripts/pages/ban.js
+++ b/public/scripts/pages/ban.js
@@ -6,7 +6,12 @@ import {
   MicOff,
   ShieldCheck,
   Sparkles,
+  Users,
+  Headphones,
+  X,
+  ArrowRight,
 } from '../core/deps.js';
+import { MODERATION_SERVICES } from '../components/index.js';
 
 const BanPage = () => html`
   <${Fragment}>


### PR DESCRIPTION
## Summary
- import the Ban page icons and moderation data it relies on to avoid runtime failures
- export the moderation services definition from the shared components module for reuse

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e0015b63188324bb745b02a4e2dacf