### PR TITLE
Document shop payment configurations in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,15 +17,50 @@ You can clear the default exclusion by explicitly setting the variable to an emp
 
 ### Boutique en ligne
 
-The shop endpoints support multiple payment providers. To enable PayPal Checkout you need to provide API credentials via environment variables:
+Les endpoints de la boutique peuvent activer plusieurs prestataires de paiement. Chaque intégration est contrôlée par des variables d’environnement :
+
+#### Stripe Checkout
 
 ```env
-# PayPal Checkout (defaults to the sandbox environment if not provided)
+# Clé API secrète Stripe (obligatoire pour activer Stripe)
+SHOP_STRIPE_SECRET_KEY=sk_live_xxx
+
+# Identifiants de prix pour les produits (configurer uniquement ceux que vous souhaitez vendre via Stripe)
+SHOP_STRIPE_PRICE_MUG=price_123
+SHOP_STRIPE_PRICE_TSHIRT=price_456
+SHOP_STRIPE_PRICE_PACK=price_789
+SHOP_STRIPE_PRICE_MODERATION=price_abc
+```
+
+Fournissez la clé secrète Stripe et au moins un identifiant de prix pour qu’un produit puisse être proposé via Stripe. Tout produit sans identifiant correspondant sera masqué du prestataire Stripe.
+
+#### PayPal Checkout
+
+```env
+# Identifiants API PayPal (utilise le sandbox par défaut si l’environnement n’est pas "live")
 SHOP_PAYPAL_CLIENT_ID=your-paypal-client-id
 SHOP_PAYPAL_CLIENT_SECRET=your-paypal-client-secret
 SHOP_PAYPAL_ENVIRONMENT=live
-# Optional: overrides the brand name displayed on the PayPal approval screen
+
+# Optionnel : nom de marque affiché sur l’interface PayPal
 SHOP_PAYPAL_BRAND_NAME=Libre Antenne
 ```
 
-Omit the variables (or leave them empty) to disable PayPal. Stripe and CoinGate keep their existing configuration options.
+Laissez ces variables vides pour désactiver PayPal.
+
+#### Virements SEPA via CoinGate
+
+CoinGate peut proposer des virements SEPA en plus des paiements crypto. Configurez-le avec les variables suivantes :
+
+```env
+# Obligatoire : active CoinGate et les virements SEPA
+SHOP_COINGATE_API_KEY=your-coingate-api-key
+
+# Optionnel : environnement (sandbox par défaut si omis ou différent de "live")
+SHOP_COINGATE_ENVIRONMENT=live
+
+# Optionnel : URL de callback utilisée par CoinGate après le paiement
+SHOP_COINGATE_CALLBACK_URL=https://example.com/shop/callback
+```
+
+Si aucune de ces variables n’est définie, CoinGate (et donc l’option virement SEPA) est désactivé.


### PR DESCRIPTION
## Summary
- document the environment variables required to enable Stripe Checkout for shop products
- clarify PayPal and CoinGate configuration details in the README

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e002093b5c8324bcbc46332dd62f2e