### PR TITLE
Fix Activity icon import in components bundle

### DIFF
--- a/public/scripts/components/index.js
+++ b/public/scripts/components/index.js
@@ -9,6 +9,7 @@ import {
   useState,
   Chart,
   THREE,
+  Activity,
   AlertCircle,
   AudioLines,
   BadgeCheck,


### PR DESCRIPTION
## Summary
- import the Activity icon from the shared deps bundle so components can reference it

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e01ff91da883249c9427a2f539b991