### PR TITLE
Add real-time listener tracking and audience history visualisation

### DIFF
--- a/public/scripts/core/constants.js
+++ b/public/scripts/core/constants.js
@@ -7,6 +7,7 @@ export const DEFAULT_WINDOW_MINUTES = TALK_WINDOW_OPTIONS.includes(15)
 export const MINUTE_MS = 60 * 1000;
 export const HOUR_MS = 60 * MINUTE_MS;
 export const DAY_MS = 24 * HOUR_MS;
+export const LISTENER_HISTORY_RETENTION_MS = 24 * HOUR_MS;
 export const HISTORY_RETENTION_MS = Math.max(
   (Math.max(...TALK_WINDOW_OPTIONS) + 5) * 60 * 1000,
   24 * 60 * 60 * 1000,

--- a/public/scripts/pages/home.js
+++ b/public/scripts/pages/home.js
@@ -4,6 +4,7 @@ import {
   Activity,
   ArrowRight,
   Users,
+  Headphones,
 } from '../core/deps.js';
 import {
   StatusBadge,
@@ -13,6 +14,7 @@ import {
   RealTimeTalkChart,
   AnonymousBooth,
   SpeakersSection,
+  ListenerTrendCard,
 } from '../components/index.js';
 
 const HomePage = ({
@@ -27,12 +29,16 @@ const HomePage = ({
   selectedWindowMinutes,
   onWindowChange,
   onViewProfile,
+  listenerStats = { count: 0, history: [] },
 }) => {
   const connectedCount = speakers.length;
   const activeSpeakersCount = speakers.reduce(
     (count, speaker) => count + (speaker?.isSpeaking ? 1 : 0),
     0,
   );
+  const listenerCount = Number.isFinite(listenerStats?.count)
+    ? Math.max(0, Math.round(listenerStats.count))
+    : 0;
 
   return html`
     <${Fragment}>
@@ -77,6 +83,8 @@ const HomePage = ({
     <${AudioPlayer} streamInfo=${streamInfo} audioKey=${audioKey} status=${status} />
   </section>
 
+  <${ListenerTrendCard} stats=${listenerStats} now=${now} />
+
   <${DailyActivityChart}
     history=${speakingHistory}
     now=${now}
@@ -116,6 +124,13 @@ const HomePage = ({
             <span aria-hidden="true" class="text-sm font-semibold tracking-normal">${activeSpeakersCount}</span>
             <span aria-hidden="true" class="text-[0.6rem] font-semibold uppercase tracking-[0.35em] text-indigo-200/80">Actifs</span>
             <span class="sr-only">personnes actives</span>
+          </span>
+          <span aria-hidden="true" class="text-indigo-300">·</span>
+          <span class="flex items-center gap-2">
+            <${Headphones} class="h-3.5 w-3.5" aria-hidden="true" />
+            <span aria-hidden="true" class="text-sm font-semibold tracking-normal">${listenerCount}</span>
+            <span aria-hidden="true" class="text-[0.6rem] font-semibold uppercase tracking-[0.35em] text-indigo-200/80">Flux</span>
+            <span class="sr-only">auditeurs du flux</span>
           </span>
         </div>
       </div>

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import DiscordAudioBridge from './discord/DiscordAudioBridge';
 import AnonymousSpeechManager from './services/AnonymousSpeechManager';
 import ShopService from './services/ShopService';
 import VoiceActivityRepository from './services/VoiceActivityRepository';
+import ListenerStatsService from './services/ListenerStatsService';
 
 const mixer = new AudioMixer({
   frameBytes: config.audio.frameBytes,
@@ -51,6 +52,8 @@ const sseService = new SseService({
   keepAliveInterval: config.keepAliveInterval,
 });
 
+const listenerStatsService = new ListenerStatsService();
+
 const voiceActivityRepository = new VoiceActivityRepository({
   url: config.database.url,
   ssl: config.database.ssl,
@@ -89,6 +92,7 @@ const appServer = new AppServer({
   discordBridge,
   shopService,
   voiceActivityRepository,
+  listenerStatsService,
 });
 appServer.start();
 
@@ -115,6 +119,12 @@ function shutdown(): void {
     sseService.closeAll();
   } catch (error) {
     console.warn('Error while closing SSE connections', error);
+  }
+
+  try {
+    listenerStatsService.stop();
+  } catch (error) {
+    console.warn('Error while stopping listener stats service', error);
   }
 
   try {

--- a/src/services/ListenerStatsService.ts
+++ b/src/services/ListenerStatsService.ts
@@ -1,0 +1,171 @@
+export type ListenerStatsReason = 'connect' | 'disconnect' | 'snapshot';
+
+export interface ListenerStatsEntry {
+  timestamp: number;
+  count: number;
+}
+
+export interface ListenerStatsUpdate {
+  entry: ListenerStatsEntry;
+  inserted: boolean;
+  count: number;
+  reason: ListenerStatsReason;
+  delta: number;
+}
+
+export interface ListenerStatsServiceOptions {
+  historyTtlMs?: number;
+  snapshotIntervalMs?: number;
+}
+
+const DEFAULT_HISTORY_TTL_MS = 24 * 60 * 60 * 1000;
+const DEFAULT_SNAPSHOT_INTERVAL_MS = 60_000;
+
+export default class ListenerStatsService {
+  private readonly historyTtlMs: number;
+
+  private readonly snapshotIntervalMs: number;
+
+  private readonly updateListeners: Set<(update: ListenerStatsUpdate) => void>;
+
+  private currentCount = 0;
+
+  private history: ListenerStatsEntry[] = [];
+
+  private snapshotTimer: NodeJS.Timeout | null = null;
+
+  constructor({ historyTtlMs, snapshotIntervalMs }: ListenerStatsServiceOptions = {}) {
+    this.historyTtlMs = Math.max(60_000, historyTtlMs ?? DEFAULT_HISTORY_TTL_MS);
+    this.snapshotIntervalMs = Math.max(1_000, snapshotIntervalMs ?? DEFAULT_SNAPSHOT_INTERVAL_MS);
+    this.updateListeners = new Set();
+
+    const now = Date.now();
+    this.history.push({ timestamp: now, count: this.currentCount });
+
+    this.startSnapshotTimer();
+  }
+
+  private startSnapshotTimer(): void {
+    if (!Number.isFinite(this.snapshotIntervalMs) || this.snapshotIntervalMs <= 0) {
+      return;
+    }
+
+    this.snapshotTimer = setInterval(() => {
+      this.recordSnapshot();
+    }, this.snapshotIntervalMs);
+
+    if (typeof this.snapshotTimer.unref === 'function') {
+      this.snapshotTimer.unref();
+    }
+  }
+
+  private notify(update: ListenerStatsUpdate): void {
+    for (const listener of this.updateListeners) {
+      try {
+        listener(update);
+      } catch (error) {
+        console.warn('Listener stats update listener failed', error);
+      }
+    }
+  }
+
+  private addEntry(entry: ListenerStatsEntry, forceInsert: boolean): { entry: ListenerStatsEntry; inserted: boolean } {
+    const timestamp = Number.isFinite(entry.timestamp) ? entry.timestamp : Date.now();
+    const count = Number.isFinite(entry.count) ? Math.max(0, Math.floor(entry.count)) : this.currentCount;
+
+    const lastIndex = this.history.length - 1;
+    const lastEntry = lastIndex >= 0 ? this.history[lastIndex] : null;
+
+    if (!forceInsert && lastEntry && lastEntry.count === count) {
+      const updated: ListenerStatsEntry = { timestamp, count };
+      this.history[lastIndex] = updated;
+      this.trimHistory(timestamp);
+      return { entry: updated, inserted: false };
+    }
+
+    const nextEntry: ListenerStatsEntry = { timestamp, count };
+    this.history.push(nextEntry);
+    this.trimHistory(timestamp);
+    return { entry: nextEntry, inserted: true };
+  }
+
+  private trimHistory(referenceTimestamp: number): void {
+    const cutoff = referenceTimestamp - this.historyTtlMs;
+    if (!Number.isFinite(cutoff)) {
+      return;
+    }
+
+    while (this.history.length > 1 && this.history[0]?.timestamp < cutoff) {
+      this.history.shift();
+    }
+  }
+
+  private recordSnapshot(): void {
+    const { entry, inserted } = this.addEntry({ timestamp: Date.now(), count: this.currentCount }, false);
+    const update: ListenerStatsUpdate = {
+      entry,
+      inserted,
+      count: this.currentCount,
+      reason: 'snapshot',
+      delta: 0,
+    };
+    this.notify(update);
+  }
+
+  public increment(): ListenerStatsUpdate {
+    const previous = this.currentCount;
+    this.currentCount += 1;
+    const { entry, inserted } = this.addEntry({ timestamp: Date.now(), count: this.currentCount }, true);
+    const update: ListenerStatsUpdate = {
+      entry,
+      inserted,
+      count: this.currentCount,
+      reason: 'connect',
+      delta: this.currentCount - previous,
+    };
+    this.notify(update);
+    return update;
+  }
+
+  public decrement(): ListenerStatsUpdate | null {
+    if (this.currentCount <= 0) {
+      return null;
+    }
+
+    const previous = this.currentCount;
+    this.currentCount = Math.max(0, this.currentCount - 1);
+    const { entry, inserted } = this.addEntry({ timestamp: Date.now(), count: this.currentCount }, true);
+    const update: ListenerStatsUpdate = {
+      entry,
+      inserted,
+      count: this.currentCount,
+      reason: 'disconnect',
+      delta: this.currentCount - previous,
+    };
+    this.notify(update);
+    return update;
+  }
+
+  public getCurrentCount(): number {
+    return this.currentCount;
+  }
+
+  public getHistory(): ListenerStatsEntry[] {
+    return this.history.map((entry) => ({ ...entry }));
+  }
+
+  public onUpdate(listener: (update: ListenerStatsUpdate) => void): () => void {
+    this.updateListeners.add(listener);
+    return () => {
+      this.updateListeners.delete(listener);
+    };
+  }
+
+  public stop(): void {
+    if (this.snapshotTimer) {
+      clearInterval(this.snapshotTimer);
+      this.snapshotTimer = null;
+    }
+    this.updateListeners.clear();
+  }
+}


### PR DESCRIPTION
## Summary
- add a listener statistics service that tracks the current audience, snapshots history and broadcasts updates
- expose listener stats through the HTTP server, including SSE payloads and a REST endpoint, and wire counting into stream connections
- surface the live listener count and a new audience trend chart on the homepage with corresponding client-side state handling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e11972f350832499207145dea681c7