### PR TITLE
Move listener trend card to bottom of home page

### DIFF
--- a/public/scripts/pages/home.js
+++ b/public/scripts/pages/home.js
@@ -83,8 +83,6 @@ const HomePage = ({
     <${AudioPlayer} streamInfo=${streamInfo} audioKey=${audioKey} status=${status} />
   </section>
 
-  <${ListenerTrendCard} stats=${listenerStats} now=${now} />
-
   <${DailyActivityChart}
     history=${speakingHistory}
     now=${now}
@@ -136,6 +134,8 @@ const HomePage = ({
       </div>
       <${SpeakersSection} speakers=${speakers} now=${now} onViewProfile=${onViewProfile} />
     </section>
+
+    <${ListenerTrendCard} stats=${listenerStats} now=${now} />
     </${Fragment}>
   `;
 };


### PR DESCRIPTION
## Summary
- reorder the listener trend card so it renders after the other home page sections

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e12c3dc9508324ad5b3cb2e239ec6a