### PR TITLE
Fix undefined icon on members page

### DIFF
--- a/public/scripts/pages/members.js
+++ b/public/scripts/pages/members.js
@@ -9,6 +9,7 @@ import {
   ArrowRight,
   BadgeCheck,
   CalendarDays,
+  X,
   RefreshCcw,
   Search,
 } from '../core/deps.js';


### PR DESCRIPTION
## Summary
- import the missing lucide `X` icon used by the members page search clear button

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e134b3fa0083249aece2b0e95822eb