### PR TITLE
Disable automatic stream playback on page load

### DIFF
--- a/public/scripts/components/index.js
+++ b/public/scripts/components/index.js
@@ -1906,17 +1906,6 @@ const AudioPlayer = ({ streamInfo, audioKey, status }) => {
     audio.load();
     setIsLoading(true);
 
-    const attemptPlay = async () => {
-      try {
-        await audio.play();
-      } catch (error) {
-        console.warn('Lecture automatique bloquée', error);
-        setIsLoading(false);
-      }
-    };
-
-    attemptPlay();
-
     return () => {
       audio.pause();
     };


### PR DESCRIPTION
## Summary
- stop triggering the audio element to play automatically when the stream loads so the user must start playback manually

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e15d85e388832489ed80dc1ede1111