### PR TITLE
Fix Express catch-all route wildcard

### DIFF
--- a/src/http/AppServer.ts
+++ b/src/http/AppServer.ts
@@ -1749,7 +1749,7 @@ export default class AppServer {
       this.respondWithAppShell(res, metadata);
     });
 
-    this.app.get('*', (req, res) => {
+    this.app.get('/*', (req, res) => {
       this.respondWithAppShell(
         res,
         {


### PR DESCRIPTION
## Summary
- update the fallback GET route to use an Express 5 compatible wildcard pattern

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e15efeb5208324bab188009109bad1