### PR TITLE
Fix catch-all route pattern for Express

### DIFF
--- a/src/http/AppServer.ts
+++ b/src/http/AppServer.ts
@@ -1749,7 +1749,7 @@ export default class AppServer {
       this.respondWithAppShell(res, metadata);
     });
 
-    this.app.get('/*', (req, res) => {
+    this.app.get('*', (req, res) => {
       this.respondWithAppShell(
         res,
         {


### PR DESCRIPTION
## Summary
- update the catch-all Express route to use the `*` pattern that is compatible with the current path-to-regexp version

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e15fe8cee4832489f556470cc101ae