### PR TITLE
Fix wildcard 404 route to prevent path-to-regexp error

### DIFF
--- a/src/http/AppServer.ts
+++ b/src/http/AppServer.ts
@@ -1749,7 +1749,7 @@ export default class AppServer {
       this.respondWithAppShell(res, metadata);
     });
 
-    this.app.get('*', (req, res) => {
+    this.app.get('/*', (req, res) => {
       this.respondWithAppShell(
         res,
         {


### PR DESCRIPTION
## Summary
- update the 404 catch-all route to use an Express 5 compatible wildcard pattern
- prevent path-to-regexp from throwing when registering the fallback handler

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e160d59a0c832485216cf0f74dd3fe