### PR TITLE
Fix wildcard route registration for Express 5

### DIFF
--- a/src/http/AppServer.ts
+++ b/src/http/AppServer.ts
@@ -1749,7 +1749,7 @@ export default class AppServer {
       this.respondWithAppShell(res, metadata);
     });
 
-    this.app.get('/*', (req, res) => {
+    this.app.get('*', (req, res) => {
       this.respondWithAppShell(
         res,
         {


### PR DESCRIPTION
## Summary
- replace the deprecated `/*` catch-all route registration with `*` for Express 5 compatibility
- ensure the fallback page can be rendered without crashing the server during startup

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e161c2db8c8324b59178a1ab77334c