### PR TITLE
Remove duplicate routing helpers and stabilize blog guards

### DIFF
--- a/public/scripts/pages/blog.js
+++ b/public/scripts/pages/blog.js
@@ -124,7 +124,7 @@ const BlogCard = ({ post, onOpen, isActive }) => {
   `;
 };
 
-export const BlogPage = ({ params = {} }) => {
+export const BlogPage = ({ params = {}, backendAvailable = true, backendOffline = false }) => {
   const slug = typeof params?.slug === 'string' && params.slug.trim().length > 0 ? params.slug.trim() : null;
   const [posts, setPosts] = useState([]);
   const [availableTags, setAvailableTags] = useState([]);
@@ -146,6 +146,19 @@ export const BlogPage = ({ params = {} }) => {
   }, []);
 
   useEffect(() => {
+    if (!backendAvailable) {
+      if (backendOffline) {
+        setIsLoadingList(false);
+        setListError('Blog indisponible tant que le serveur est hors ligne.');
+        setPosts([]);
+        setAvailableTags([]);
+      } else {
+        setIsLoadingList(true);
+        setListError(null);
+      }
+      return undefined;
+    }
+
     let cancelled = false;
     const controller = typeof AbortController !== 'undefined' ? new AbortController() : null;
 
@@ -189,13 +202,25 @@ export const BlogPage = ({ params = {} }) => {
       cancelled = true;
       controller?.abort();
     };
-  }, [debouncedSearch, selectedTags]);
+  }, [backendAvailable, backendOffline, debouncedSearch, selectedTags]);
 
   useEffect(() => {
     if (!slug) {
       setActivePost(null);
       setPostError(null);
       setIsLoadingPost(false);
+      return;
+    }
+
+    if (!backendAvailable) {
+      if (backendOffline) {
+        setActivePost(null);
+        setPostError('Blog indisponible tant que le serveur est hors ligne.');
+        setIsLoadingPost(false);
+      } else {
+        setIsLoadingPost(true);
+        setPostError(null);
+      }
       return;
     }
 
@@ -242,7 +267,7 @@ export const BlogPage = ({ params = {} }) => {
       cancelled = true;
       controller?.abort();
     };
-  }, [slug]);
+  }, [backendAvailable, backendOffline, slug]);
 
   useEffect(() => {
     const baseTitle = 'Blog · Libre Antenne';

--- a/public/scripts/pages/classements.js
+++ b/public/scripts/pages/classements.js
@@ -165,7 +165,7 @@ const getTrendPresentation = (positionTrend) => {
   }
 };
 
-const ClassementsPage = ({ params = {} }) => {
+const ClassementsPage = ({ params = {}, backendAvailable = true, backendOffline = false }) => {
   const initialState = useMemo(() => deriveInitialState(params), [params.search, params.sortBy, params.sortOrder, params.period]);
   const [search, setSearch] = useState(initialState.search);
   const [debouncedSearch, setDebouncedSearch] = useState(initialState.search.trim());
@@ -246,6 +246,21 @@ const ClassementsPage = ({ params = {} }) => {
   }, []);
 
   useEffect(() => {
+    if (!backendAvailable) {
+      if (backendOffline) {
+        setIsLoading(false);
+        setIsRefreshing(false);
+        setError(new Error('Classements indisponibles tant que le serveur est hors ligne.'));
+        setLeaders([]);
+        setSnapshot(null);
+        hasLoadedRef.current = false;
+      } else {
+        setIsLoading(true);
+        setIsRefreshing(false);
+      }
+      return undefined;
+    }
+
     const controller = new AbortController();
     if (controllerRef.current) {
       controllerRef.current.abort();
@@ -311,7 +326,7 @@ const ClassementsPage = ({ params = {} }) => {
       controller.abort();
       controllerRef.current = null;
     };
-  }, [debouncedSearch, sortBy, sortOrder, period, refreshTick]);
+  }, [backendAvailable, debouncedSearch, sortBy, sortOrder, period, refreshTick]);
 
   useEffect(() => {
     const params = new URLSearchParams();

--- a/public/scripts/pages/home.js
+++ b/public/scripts/pages/home.js
@@ -30,6 +30,8 @@ const HomePage = ({
   onWindowChange,
   onViewProfile,
   listenerStats = { count: 0, history: [] },
+  backendAvailable = true,
+  backendOffline = false,
 }) => {
   const connectedCount = speakers.length;
   const activeSpeakersCount = speakers.reduce(
@@ -80,7 +82,13 @@ const HomePage = ({
           </p>
         </div>
       </div>
-    <${AudioPlayer} streamInfo=${streamInfo} audioKey=${audioKey} status=${status} />
+    <${AudioPlayer}
+      streamInfo=${streamInfo}
+      audioKey=${audioKey}
+      status=${status}
+      canPlayStream=${backendAvailable}
+      isServerOffline=${backendOffline}
+    />
   </section>
 
   <${DailyActivityChart}

--- a/public/scripts/pages/members.js
+++ b/public/scripts/pages/members.js
@@ -18,7 +18,7 @@ import { formatDateTimeLabel } from '../utils/index.js';
 
 const MEMBERS_PAGE_SIZE = 24;
 
-const MembersPage = ({ onViewProfile }) => {
+const MembersPage = ({ onViewProfile, backendAvailable = true, backendOffline = false }) => {
   const [members, setMembers] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
@@ -54,6 +54,19 @@ const MembersPage = ({ onViewProfile }) => {
     const controller = new AbortController();
 
     const loadMembers = async () => {
+      if (!backendAvailable) {
+        if (backendOffline) {
+          setLoading(false);
+          setError('Les membres sont indisponibles tant que le serveur est hors ligne.');
+          setMembers([]);
+          setNextCursor(null);
+        } else {
+          setLoading(true);
+          setError('');
+        }
+        return;
+      }
+
       setLoading(true);
       setError('');
       setNextCursor(null);
@@ -123,7 +136,7 @@ const MembersPage = ({ onViewProfile }) => {
       isActive = false;
       controller.abort();
     };
-  }, [currentCursor, searchTerm, refreshNonce]);
+  }, [backendAvailable, backendOffline, currentCursor, searchTerm, refreshNonce]);
 
   const handleSearchSubmit = useCallback(
     (event) => {

--- a/public/scripts/pages/profile.js
+++ b/public/scripts/pages/profile.js
@@ -29,7 +29,7 @@ import {
   ProfileMessagesCard,
 } from '../components/index.js';
 
-const ProfilePage = ({ params, onNavigateHome, onUpdateRange }) => {
+const ProfilePage = ({ params, onNavigateHome, onUpdateRange, backendAvailable = true, backendOffline = false }) => {
   const userId = typeof params?.userId === 'string' && params.userId.trim().length > 0 ? params.userId.trim() : null;
   const [range, setRange] = useState(() => normalizeProfileRange(params ?? {}));
   const [draftSince, setDraftSince] = useState(() => toInputValue(range.sinceMs));
@@ -66,6 +66,15 @@ const ProfilePage = ({ params, onNavigateHome, onUpdateRange }) => {
     const sinceMs = range.sinceMs;
     const untilMs = range.untilMs;
     if (!Number.isFinite(sinceMs) || !Number.isFinite(untilMs) || untilMs <= sinceMs) {
+      return undefined;
+    }
+
+    if (!backendAvailable) {
+      if (backendOffline) {
+        setState({ status: 'error', data: null, error: 'Profil indisponible tant que le serveur est hors ligne.' });
+      } else {
+        setState((prev) => ({ status: 'loading', data: prev.data, error: null }));
+      }
       return undefined;
     }
 
@@ -120,7 +129,7 @@ const ProfilePage = ({ params, onNavigateHome, onUpdateRange }) => {
 
     fetchProfile();
     return () => controller?.abort();
-  }, [userId, range.sinceMs, range.untilMs, refreshNonce]);
+  }, [backendAvailable, backendOffline, userId, range.sinceMs, range.untilMs, refreshNonce]);
 
   const handleBack = useCallback(
     (event) => {


### PR DESCRIPTION
## Summary
- remove the duplicate backend availability polling and routing helper definitions in the app shell so history/state effects only register once
- retain the SSE event handling while keeping a single source of truth for route transitions and profile navigation helpers
- ensure the blog page respects the backend offline flag without retrying fetches when the server is unavailable

## Testing
- npm run build
- Playwright console smoke check (browser_container)


------
https://chatgpt.com/codex/tasks/task_e_68e169c6538c83248b1d597978b51721