### PR TITLE
Allow offline dev mode and fix blog cover URLs

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,5 @@
 import dotenv from 'dotenv';
+import ffmpegStatic from 'ffmpeg-static';
 
 dotenv.config();
 
@@ -115,7 +116,7 @@ const config: Config = {
   guildId: process.env.GUILD_ID,
   voiceChannelId: process.env.VOICE_CHANNEL_ID,
   port: parseInteger(process.env.PORT, 3000),
-  ffmpegPath: process.env.FFMPEG_PATH || 'ffmpeg',
+  ffmpegPath: process.env.FFMPEG_PATH || ffmpegStatic || 'ffmpeg',
   outputFormat,
   opusBitrate: process.env.OPUS_BITRATE || '64000',
   mp3Bitrate: process.env.MP3_BITRATE || '96000',
@@ -202,8 +203,7 @@ config.audio.frameBytes =
   config.audio.frameSamples * config.audio.channels * config.audio.bytesPerSample;
 
 if (!config.botToken) {
-  console.error('BOT_TOKEN is required in the environment');
-  process.exit(1);
+  console.warn('BOT_TOKEN is not set; Discord features will be disabled.');
 }
 
 export default config;

--- a/src/discord/NullDiscordAudioBridge.ts
+++ b/src/discord/NullDiscordAudioBridge.ts
@@ -1,0 +1,83 @@
+import { EventEmitter } from 'node:events';
+import type { VoiceConnection } from '@discordjs/voice';
+import type {
+  DiscordAudioBridgeOptions,
+  DiscordUserIdentity,
+  GuildMembersListOptions,
+  GuildMembersListResult,
+} from './DiscordAudioBridge';
+
+const DISCORD_DISABLED_ERROR = 'DISCORD_DISABLED';
+
+export default class NullDiscordAudioBridge {
+  private readonly events = new EventEmitter();
+
+  constructor(_options: DiscordAudioBridgeOptions) {}
+
+  public async login(): Promise<void> {
+    console.warn('Discord bridge disabled: skipping login.');
+  }
+
+  public async destroy(): Promise<void> {
+    // Nothing to clean up in offline mode.
+  }
+
+  public async fetchUserIdentity(_userId: string): Promise<DiscordUserIdentity | null> {
+    return null;
+  }
+
+  public async listGuildMembers({
+    limit = 0,
+    after = null,
+    search = null,
+  }: GuildMembersListOptions = {}): Promise<GuildMembersListResult> {
+    const sanitizedLimit = Number.isFinite(limit) && limit ? Math.max(0, Math.floor(limit)) : 0;
+    if (sanitizedLimit > 0 && (after || search)) {
+      console.debug('Guild member listing requested while Discord bridge is disabled.', {
+        limit: sanitizedLimit,
+        after,
+        search,
+      });
+    }
+
+    return {
+      members: [],
+      nextCursor: null,
+      hasMore: false,
+    };
+  }
+
+  public async joinVoice(): Promise<VoiceConnection> {
+    const error = new Error('Voice connection unavailable while Discord bridge is disabled.');
+    error.name = DISCORD_DISABLED_ERROR;
+    throw error;
+  }
+
+  public leaveVoice(): void {
+    // Nothing to do.
+  }
+
+  public hasActiveVoiceConnection(): boolean {
+    return false;
+  }
+
+  public pushAnonymousAudio(_chunk: Buffer): boolean {
+    return false;
+  }
+
+  public onVoiceConnectionReady(listener: (connection: VoiceConnection) => void): void {
+    this.events.on('voiceConnectionReady', listener);
+  }
+
+  public offVoiceConnectionReady(listener: (connection: VoiceConnection) => void): void {
+    this.events.off('voiceConnectionReady', listener);
+  }
+
+  public onVoiceConnectionDestroyed(listener: () => void): void {
+    this.events.on('voiceConnectionDestroyed', listener);
+  }
+
+  public offVoiceConnectionDestroyed(listener: () => void): void {
+    this.events.off('voiceConnectionDestroyed', listener);
+  }
+}

--- a/src/services/BlogService.ts
+++ b/src/services/BlogService.ts
@@ -142,8 +142,18 @@ const normalizeCoverImage = (value: string | undefined | null): string | null =>
   if (!value) {
     return null;
   }
-  const trimmed = value.trim();
-  return trimmed ? trimmed : null;
+
+  let normalized = value.trim();
+  if (!normalized) {
+    return null;
+  }
+
+  normalized = normalized.replace(/^['"]+/, '').replace(/['"]+$/, '').trim();
+  if (!normalized) {
+    return null;
+  }
+
+  return normalized;
 };
 
 const parseTags = (value: string | undefined | null): string[] => {


### PR DESCRIPTION
## Summary
- fall back to the bundled ffmpeg binary and skip Discord login when no bot token is provided so the web UI can run locally
- add a null Discord bridge implementation so HTTP endpoints keep working in offline mode
- strip stray quotes from blog cover image URLs to prevent 404s in the browser

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e170c3448083248baba55bdbc4f418