### PR TITLE
Improve mobile layout responsiveness

### DIFF
--- a/public/scripts/components/index.js
+++ b/public/scripts/components/index.js
@@ -3359,7 +3359,7 @@ const BeerCanDisplay = () => {
 
     container.innerHTML = '';
     container.appendChild(renderer.domElement);
-    container.style.touchAction = 'none';
+    container.style.touchAction = 'pan-y';
     container.style.cursor = 'grab';
 
     const ambientLight = new THREE.AmbientLight(0xffffff, 1.1);

--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -1043,12 +1043,16 @@ const App = () => {
                     key=${`previous-${transitionState.id}-${buildRouteKey(transitionState.previous)}`}
                     class=${previousLayerClasses.join(' ')}
                   >
-                    ${previousPageTemplate}
+                    <div class="page-transition-layer__content">
+                      ${previousPageTemplate}
+                    </div>
                   </div>`
                 : null
             }
             <div key=${`current-${buildRouteKey(route)}`} class=${currentLayerClasses.join(' ')}>
-              ${currentPageTemplate}
+              <div class="page-transition-layer__content">
+                ${currentPageTemplate}
+              </div>
             </div>
             ${
               transitionState.active

--- a/public/styles/app.css
+++ b/public/styles/app.css
@@ -1,5 +1,10 @@
+html {
+  overflow-x: hidden;
+}
+
 body {
   font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  overflow-x: hidden;
 }
 
 .speaker-card {

--- a/public/styles/app.css
+++ b/public/styles/app.css
@@ -223,6 +223,18 @@ body {
   transition: filter 0.3s ease;
 }
 
+.page-transition-layer__content {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.75rem, 6vw, 3rem);
+  width: 100%;
+  min-width: 0;
+}
+
+.page-transition-layer__content > * {
+  width: 100%;
+}
+
 .page-transition-layer--previous {
   z-index: 1;
   pointer-events: none;


### PR DESCRIPTION
## Summary
- prevent mobile horizontal scrolling caused by decorative glows by hiding horizontal overflow on the root layout
- allow vertical scrolling while interacting with the BeerCanDisplay by switching its touch-action to `pan-y`

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e184538c308324a6dc54533b578af7