### PR TITLE
Remove test beep button and adjust mobile padding

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -100,16 +100,6 @@
   <body class="min-h-screen bg-slate-950 text-slate-100 antialiased">
     <div id="app" class="min-h-screen"></div>
 
-    
-    
-    <button
-      id="test-beep-trigger"
-      type="button"
-      aria-label="Déclencher un bip de test"
-      title="Bip test bot"
-      class="fixed bottom-2 right-2 z-40 h-12 w-12 rounded-full border border-white/10 bg-white/20 opacity-20 transition duration-150 ease-out hover:opacity-60 focus-visible:opacity-70 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/40"
-    ></button>
-
       <script type="module" src="/scripts/main.js"></script>
 </body>
 </html>

--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -725,7 +725,7 @@ const App = () => {
       </header>
 
       <main class="flex-1">
-        <div class="mx-auto flex w-full max-w-5xl flex-col gap-10 py-10">
+        <div class="mx-auto flex w-full max-w-5xl flex-col gap-10 px-4 py-10 sm:px-6 lg:px-0">
           ${
             route.name === 'ban'
               ? html`<${BanPage} />`
@@ -785,34 +785,3 @@ if ('serviceWorker' in navigator) {
       });
   });
 }
-(() => {
-  const button = document.getElementById('test-beep-trigger');
-  if (!button) {
-    return;
-  }
-
-  let pending = false;
-  button.addEventListener('click', async () => {
-    if (pending) {
-      return;
-    }
-
-    pending = true;
-    const previousOpacity = button.style.opacity;
-    button.style.opacity = '0.65';
-
-    try {
-      const response = await fetch('/test-beep', { method: 'POST' });
-      if (!response.ok) {
-        console.warn('Réponse inattendue pour le bip de test', response.status);
-      }
-    } catch (error) {
-      console.warn('Impossible de déclencher le bip de test', error);
-    } finally {
-      setTimeout(() => {
-        button.style.opacity = previousOpacity;
-      }, 150);
-      pending = false;
-    }
-  });
-})();


### PR DESCRIPTION
## Summary
- remove the unused test beep trigger button from the static index page
- add responsive horizontal padding to the main content container so content does not touch the screen edges on mobile

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e19a51191c8324922532906def4816