### PR TITLE
Add blog article proposal workflow

### DIFF
--- a/public/scripts/core/deps.js
+++ b/public/scripts/core/deps.js
@@ -10,6 +10,7 @@ import {
 import htm from 'https://esm.sh/htm@3.1.1?deps=preact@10.19.2';
 import Chart from 'https://esm.sh/chart.js@4.4.2/auto';
 import * as THREE from 'https://esm.sh/three@0.161.0';
+import { marked } from 'https://esm.sh/marked@12.0.2?deps=preact@10.19.2';
 import {
   Activity,
   AlertCircle,
@@ -96,4 +97,5 @@ export {
   Volume2,
   VolumeX,
   X,
+  marked,
 };

--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -39,6 +39,7 @@ import { BanPage } from './pages/ban.js';
 import { AboutPage } from './pages/about.js';
 import { ClassementsPage } from './pages/classements.js';
 import { BlogPage } from './pages/blog.js';
+import { BlogProposalPage } from './pages/blog-proposal.js';
 
 const NAV_LINKS = [
   { label: 'Accueil', route: 'home', hash: '#/', icon: AudioLines },
@@ -93,11 +94,17 @@ const getRouteFromHash = () => {
     return { name: 'classements', params };
   }
   if (head === 'blog') {
-    const slug = segments.length > 1 ? segments[1] : null;
+    const second = segments.length > 1 ? segments[1] : null;
+    if (second) {
+      const normalized = second.toLowerCase();
+      if (['proposer', 'proposal', 'soumettre'].includes(normalized)) {
+        return { name: 'blog-proposal', params: {} };
+      }
+    }
     return {
       name: 'blog',
       params: {
-        slug: slug ? decodeURIComponent(slug) : null,
+        slug: second ? decodeURIComponent(second) : null,
       },
     };
   }
@@ -763,9 +770,10 @@ const App = () => {
             Libre Antenne
           </a>
           <nav class="hidden items-center gap-6 lg:flex">
-            ${NAV_LINKS.map((link) => {
-              const isActive = route.name === link.route;
-              const href = link.external && link.href ? link.href : link.hash;
+          ${NAV_LINKS.map((link) => {
+            const isActive =
+              route.name === link.route || (link.route === 'blog' && route.name === 'blog-proposal');
+            const href = link.external && link.href ? link.href : link.hash;
               const baseClasses = 'text-sm font-medium transition hover:text-white';
               const stateClass = isActive ? 'text-white' : 'text-slate-300';
               return html`
@@ -832,7 +840,8 @@ const App = () => {
         </div>
         <nav class="mt-8 flex flex-col gap-1" aria-label="Navigation mobile">
           ${NAV_LINKS.map((link) => {
-            const isActive = route.name === link.route;
+            const isActive =
+              route.name === link.route || (link.route === 'blog' && route.name === 'blog-proposal');
             const href = link.external && link.href ? link.href : link.hash;
             const baseClasses = 'flex items-center gap-3 rounded-xl px-3 py-3 text-base font-medium transition';
             const stateClass = isActive
@@ -864,6 +873,8 @@ const App = () => {
               ? html`<${AboutPage} />`
               : route.name === 'blog'
               ? html`<${BlogPage} params=${route.params} />`
+              : route.name === 'blog-proposal'
+              ? html`<${BlogProposalPage} />`
               : route.name === 'members'
               ? html`<${MembersPage} onViewProfile=${handleProfileOpen} />`
               : route.name === 'shop'

--- a/public/scripts/pages/blog-proposal.js
+++ b/public/scripts/pages/blog-proposal.js
@@ -1,0 +1,484 @@
+import {
+  html,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  marked,
+  ArrowLeft,
+  AlertCircle,
+  Sparkles,
+} from '../core/deps.js';
+
+const initialFormState = {
+  title: '',
+  slug: '',
+  excerpt: '',
+  coverImageUrl: '',
+  tags: '',
+  seoDescription: '',
+  contentMarkdown: '',
+  authorName: '',
+  authorContact: '',
+};
+
+const slugify = (value) => {
+  if (typeof value !== 'string') {
+    return '';
+  }
+  const normalized = value
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 120);
+  return normalized;
+};
+
+const parseTags = (value) =>
+  value
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter((entry, index, array) => entry.length > 0 && array.indexOf(entry) === index)
+    .slice(0, 10);
+
+const validateForm = (form) => {
+  const errors = {};
+  const title = form.title.trim();
+  if (!title) {
+    errors.title = 'Le titre est requis.';
+  } else if (title.length > 160) {
+    errors.title = 'Le titre est trop long (160 caractères max).';
+  }
+
+  const slug = form.slug.trim();
+  if (slug && !/^[-a-zA-Z0-9_]+$/.test(slug)) {
+    errors.slug = 'Seuls les lettres, chiffres, tirets et underscores sont autorisés.';
+  } else if (slug.length > 120) {
+    errors.slug = 'Le lien personnalisé est trop long (120 caractères max).';
+  }
+
+  const excerpt = form.excerpt.trim();
+  if (excerpt.length > 320) {
+    errors.excerpt = 'L’accroche doit contenir 320 caractères maximum.';
+  }
+
+  const seoDescription = form.seoDescription.trim();
+  if (seoDescription.length > 320) {
+    errors.seoDescription = 'La description SEO doit contenir 320 caractères maximum.';
+  }
+
+  const content = form.contentMarkdown.trim();
+  if (!content) {
+    errors.contentMarkdown = 'Le contenu en Markdown est requis.';
+  } else if (content.length > 50_000) {
+    errors.contentMarkdown = 'Le contenu est trop long (limite 50 000 caractères).';
+  }
+
+  const coverUrl = form.coverImageUrl.trim();
+  if (coverUrl) {
+    try {
+      const url = new URL(coverUrl);
+      if (!['http:', 'https:'].includes(url.protocol)) {
+        throw new Error('invalid protocol');
+      }
+    } catch (_error) {
+      errors.coverImageUrl = 'Le lien de l’illustration doit être une URL valide.';
+    }
+  }
+
+  if (form.authorName.trim().length > 160) {
+    errors.authorName = 'Ce champ est trop long (160 caractères max).';
+  }
+
+  if (form.authorContact.trim().length > 160) {
+    errors.authorContact = 'Ce champ est trop long (160 caractères max).';
+  }
+
+  return errors;
+};
+
+const inputClasses = (hasError) =>
+  [
+    'w-full rounded-xl border bg-slate-900/80 py-2 px-3 text-sm text-white placeholder:text-slate-500 focus:outline-none focus:ring-2',
+    hasError
+      ? 'border-rose-400/60 focus:border-rose-400 focus:ring-rose-300'
+      : 'border-slate-700 focus:border-amber-400 focus:ring-amber-300',
+  ].join(' ');
+
+export const BlogProposalPage = () => {
+  const [form, setForm] = useState(initialFormState);
+  const [formErrors, setFormErrors] = useState({});
+  const [status, setStatus] = useState({ submitting: false, success: false, message: '', reference: null });
+
+  useEffect(() => {
+    document.title = 'Proposer un article · Libre Antenne';
+    return () => {
+      document.title = 'Libre Antenne · Radio libre et streaming communautaire';
+    };
+  }, []);
+
+  const derivedSlug = useMemo(() => {
+    const source = form.slug.trim() || form.title.trim();
+    const normalized = slugify(source);
+    return normalized || 'titre-de-ton-article';
+  }, [form.slug, form.title]);
+
+  const tagList = useMemo(() => parseTags(form.tags), [form.tags]);
+
+  const coverPreview = useMemo(() => {
+    const url = form.coverImageUrl.trim();
+    if (!url) {
+      return null;
+    }
+    try {
+      const parsed = new URL(url);
+      if (!['http:', 'https:'].includes(parsed.protocol)) {
+        return null;
+      }
+      return url;
+    } catch (_error) {
+      return null;
+    }
+  }, [form.coverImageUrl]);
+
+  const previewHtml = useMemo(() => {
+    const content = form.contentMarkdown.trim();
+    if (!content) {
+      return '<p class="text-sm text-slate-400">Commence à écrire ton article en Markdown pour voir l’aperçu.</p>';
+    }
+    try {
+      return marked.parse(content);
+    } catch (error) {
+      console.warn('Impossible de générer la prévisualisation Markdown', error);
+      return '<p class="text-sm text-rose-200">Impossible de générer un aperçu pour le moment.</p>';
+    }
+  }, [form.contentMarkdown]);
+
+  const handleInputChange = useCallback((field) => (event) => {
+    const value = event.target.value;
+    setForm((prev) => ({ ...prev, [field]: value }));
+    setFormErrors((prev) => ({ ...prev, [field]: undefined }));
+  }, []);
+
+  const handleSubmit = useCallback(
+    async (event) => {
+      event.preventDefault();
+      const errors = validateForm(form);
+      if (Object.keys(errors).length > 0) {
+        setFormErrors(errors);
+        setStatus({ submitting: false, success: false, message: 'Corrige les informations indiquées en rouge.', reference: null });
+        return;
+      }
+
+      setStatus({ submitting: true, success: false, message: '', reference: null });
+
+      const payload = {
+        title: form.title.trim(),
+        slug: form.slug.trim() || null,
+        excerpt: form.excerpt.trim() || null,
+        coverImageUrl: form.coverImageUrl.trim() || null,
+        tags: tagList,
+        seoDescription: form.seoDescription.trim() || null,
+        contentMarkdown: form.contentMarkdown,
+        authorName: form.authorName.trim() || null,
+        authorContact: form.authorContact.trim() || null,
+      };
+
+      try {
+        const response = await fetch('/api/blog/proposals', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        });
+
+        const data = await response.json().catch(() => ({}));
+
+        if (!response.ok) {
+          const message = data?.message || 'Impossible d’envoyer ta proposition pour le moment.';
+          setStatus({ submitting: false, success: false, message, reference: null });
+          if (data?.details && typeof data.details === 'object') {
+            setFormErrors((prev) => ({ ...prev, ...data.details }));
+          }
+          return;
+        }
+
+        setForm(initialFormState);
+        setFormErrors({});
+        setStatus({
+          submitting: false,
+          success: true,
+          message:
+            data?.message ||
+            'Merci ! Ton article a bien été transmis à la rédaction. Nous reviendrons vers toi rapidement.',
+          reference: data?.proposal?.reference || null,
+        });
+      } catch (error) {
+        console.error('Blog proposal submission failed', error);
+        setStatus({
+          submitting: false,
+          success: false,
+          message: 'Une erreur inattendue est survenue. Merci de réessayer dans quelques minutes.',
+          reference: null,
+        });
+      }
+    },
+    [form, tagList],
+  );
+
+  const handleBackToBlog = useCallback((event) => {
+    event.preventDefault();
+    if (window.location.hash !== '#/blog') {
+      window.location.hash = '#/blog';
+    } else {
+      window.dispatchEvent(new HashChangeEvent('hashchange'));
+    }
+  }, []);
+
+  const submitButtonLabel = status.submitting ? 'Envoi en cours…' : 'Envoyer ma proposition';
+
+  return html`
+    <section class="blog-proposal-page space-y-10 px-4 pb-16">
+      <div class="mx-auto flex w-full max-w-5xl flex-col gap-6">
+        <div class="flex items-center gap-3 text-sm">
+          <a
+            href="#/blog"
+            onClick=${handleBackToBlog}
+            class="inline-flex items-center gap-2 rounded-full border border-slate-700 bg-slate-900/70 px-4 py-2 text-slate-200 transition hover:border-amber-400/60 hover:text-amber-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300"
+          >
+            <${ArrowLeft} class="h-4 w-4" aria-hidden="true" />
+            Retour au blog
+          </a>
+          <span class="text-slate-500">/</span>
+          <span class="text-slate-300">Nouvelle contribution</span>
+        </div>
+        <header class="space-y-4 rounded-3xl border border-slate-800/70 bg-slate-950/70 p-8 shadow-xl">
+          <span class="inline-flex items-center gap-2 rounded-full border border-amber-400/40 bg-amber-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-amber-100">
+            <${Sparkles} class="h-3.5 w-3.5" aria-hidden="true" />
+            Contribution communauté
+          </span>
+          <h1 class="text-3xl font-semibold text-white sm:text-4xl">Proposer un article au blog</h1>
+          <p class="max-w-3xl text-base text-slate-300">
+            Raconte les coulisses d’un projet, partage ton expérience sur la station ou mets en lumière un moment marquant.
+            Tu peux écrire en <strong>Markdown</strong>, ajouter une image d’illustration, des tags et une description SEO. Notre équipe relira ta proposition avant publication.
+          </p>
+        </header>
+        ${status.message
+          ? html`
+              <div
+                class=${[
+                  'rounded-2xl border px-4 py-3 text-sm shadow-lg sm:px-6 sm:py-4',
+                  status.success
+                    ? 'border-emerald-400/40 bg-emerald-500/10 text-emerald-100'
+                    : 'border-rose-400/50 bg-rose-500/10 text-rose-100',
+                ].join(' ')}
+              >
+                ${status.success
+                  ? html`<p class="font-semibold">${status.message}</p>`
+                  : html`<p class="font-medium">${status.message}</p>`}
+                ${status.reference
+                  ? html`<p class="mt-1 text-xs uppercase tracking-wide text-emerald-200/90">Référence : ${status.reference}</p>`
+                  : null}
+              </div>
+            `
+          : null}
+        <form
+          class="space-y-10 rounded-3xl border border-slate-800/70 bg-slate-950/70 p-8 shadow-xl"
+          onSubmit=${handleSubmit}
+        >
+          <div class="grid gap-8 lg:grid-cols-[1.2fr_1fr]">
+            <div class="space-y-6">
+              <div class="space-y-2">
+                <label class="text-sm font-medium text-slate-200" for="proposal-title">Titre</label>
+                <input
+                  id="proposal-title"
+                  type="text"
+                  value=${form.title}
+                  onInput=${handleInputChange('title')}
+                  placeholder="Un titre accrocheur pour ton article"
+                  class=${inputClasses(Boolean(formErrors.title))}
+                  required
+                />
+                ${formErrors.title
+                  ? html`<p class="text-xs text-rose-300">${formErrors.title}</p>`
+                  : html`<p class="text-xs text-slate-400">Astuce : pense à intégrer le sujet principal du billet.</p>`}
+              </div>
+              <div class="grid gap-4 sm:grid-cols-2">
+                <div class="space-y-2">
+                  <label class="text-sm font-medium text-slate-200" for="proposal-slug">Lien personnalisé (optionnel)</label>
+                  <input
+                    id="proposal-slug"
+                    type="text"
+                    value=${form.slug}
+                    onInput=${handleInputChange('slug')}
+                    placeholder="ex: interventions-marquantes"
+                    class=${inputClasses(Boolean(formErrors.slug))}
+                  />
+                  <p class=${`text-xs ${formErrors.slug ? 'text-rose-300' : 'text-slate-400'}`}>
+                    ${formErrors.slug ?? `Le lien apparaîtra sous la forme /blog/${derivedSlug}`}
+                  </p>
+                </div>
+                <div class="space-y-2">
+                  <label class="text-sm font-medium text-slate-200" for="proposal-tags">Tags</label>
+                  <input
+                    id="proposal-tags"
+                    type="text"
+                    value=${form.tags}
+                    onInput=${handleInputChange('tags')}
+                    placeholder="technique, coulisses, communauté"
+                    class=${inputClasses(false)}
+                  />
+                  <p class="text-xs text-slate-400">Sépare les tags par une virgule (10 maximum).</p>
+                </div>
+              </div>
+              ${tagList.length > 0
+                ? html`
+                    <div class="flex flex-wrap gap-2 text-xs text-slate-200">
+                      ${tagList.map(
+                        (tag) => html`<span key=${`tag-${tag}`} class="rounded-full border border-slate-700 bg-slate-900/70 px-3 py-1">${tag}</span>`,
+                      )}
+                    </div>
+                  `
+                : null}
+              <div class="space-y-2">
+                <label class="text-sm font-medium text-slate-200" for="proposal-excerpt">Accroche (optionnel)</label>
+                <textarea
+                  id="proposal-excerpt"
+                  rows="3"
+                  value=${form.excerpt}
+                  onInput=${handleInputChange('excerpt')}
+                  placeholder="Une courte introduction qui donne envie de lire l’article."
+                  class=${inputClasses(Boolean(formErrors.excerpt))}
+                ></textarea>
+                ${formErrors.excerpt
+                  ? html`<p class="text-xs text-rose-300">${formErrors.excerpt}</p>`
+                  : html`<p class="text-xs text-slate-400">Utilisée comme prévisualisation sur le blog et les réseaux sociaux.</p>`}
+              </div>
+              <div class="space-y-2">
+                <label class="text-sm font-medium text-slate-200" for="proposal-cover">Image d’illustration (URL)</label>
+                <input
+                  id="proposal-cover"
+                  type="url"
+                  value=${form.coverImageUrl}
+                  onInput=${handleInputChange('coverImageUrl')}
+                  placeholder="https://..."
+                  class=${inputClasses(Boolean(formErrors.coverImageUrl))}
+                />
+                ${formErrors.coverImageUrl
+                  ? html`<p class="text-xs text-rose-300">${formErrors.coverImageUrl}</p>`
+                  : html`<p class="text-xs text-slate-400">Utilise un lien direct vers une image en haute qualité.</p>`}
+                ${coverPreview
+                  ? html`<img
+                      src=${coverPreview}
+                      alt="Aperçu de l’illustration"
+                      loading="lazy"
+                      class="mt-3 w-full rounded-2xl border border-slate-800/70 object-cover shadow-inner"
+                    />`
+                  : null}
+              </div>
+              <div class="space-y-2">
+                <label class="text-sm font-medium text-slate-200" for="proposal-seo">Description SEO (optionnel)</label>
+                <textarea
+                  id="proposal-seo"
+                  rows="2"
+                  value=${form.seoDescription}
+                  onInput=${handleInputChange('seoDescription')}
+                  placeholder="Ce texte apparaîtra sur Google et les réseaux sociaux."
+                  class=${inputClasses(Boolean(formErrors.seoDescription))}
+                ></textarea>
+                ${formErrors.seoDescription
+                  ? html`<p class="text-xs text-rose-300">${formErrors.seoDescription}</p>`
+                  : html`<p class="text-xs text-slate-400">Entre 150 et 320 caractères pour un affichage optimal.</p>`}
+              </div>
+              <div class="grid gap-4 sm:grid-cols-2">
+                <div class="space-y-2">
+                  <label class="text-sm font-medium text-slate-200" for="proposal-author">Ton nom ou pseudo (optionnel)</label>
+                  <input
+                    id="proposal-author"
+                    type="text"
+                    value=${form.authorName}
+                    onInput=${handleInputChange('authorName')}
+                    placeholder="ex : Romain, Luna, @pseudo"
+                    class=${inputClasses(Boolean(formErrors.authorName))}
+                  />
+                  ${formErrors.authorName ? html`<p class="text-xs text-rose-300">${formErrors.authorName}</p>` : null}
+                </div>
+                <div class="space-y-2">
+                  <label class="text-sm font-medium text-slate-200" for="proposal-contact">Contact (optionnel)</label>
+                  <input
+                    id="proposal-contact"
+                    type="text"
+                    value=${form.authorContact}
+                    onInput=${handleInputChange('authorContact')}
+                    placeholder="Adresse e-mail ou pseudo Discord"
+                    class=${inputClasses(Boolean(formErrors.authorContact))}
+                  />
+                  ${formErrors.authorContact ? html`<p class="text-xs text-rose-300">${formErrors.authorContact}</p>` : null}
+                </div>
+              </div>
+            </div>
+            <aside class="space-y-4 rounded-2xl border border-slate-800/70 bg-slate-900/60 p-6 shadow-inner">
+              <h2 class="text-base font-semibold text-white">Conseils rapides</h2>
+              <ul class="space-y-3 text-sm text-slate-300">
+                <li><strong>#</strong> Titre de niveau 1, <strong>##</strong> sous-titre.</li>
+                <li>Utilise <code>**texte**</code> pour le gras et <code>*texte*</code> pour l’italique.</li>
+                <li>Insère une image avec <code>!&#91;légende](https://...)</code>.</li>
+                <li>Tu peux créer des listes : <code>- élément</code> ou <code>1. élément</code>.</li>
+                <li>N’oublie pas d’ajouter des liens : <code>[libre-antenne](https://libre-antenne.xyz)</code>.</li>
+              </ul>
+              <div class="rounded-xl border border-amber-400/30 bg-amber-500/10 px-4 py-3 text-xs text-amber-100">
+                Une fois validé, l’article peut être retravaillé par l’équipe éditoriale (titre, image, mise en forme…).
+              </div>
+            </aside>
+          </div>
+          <div class="grid gap-6 lg:grid-cols-2">
+            <div class="space-y-2">
+              <label class="text-sm font-medium text-slate-200" for="proposal-content">Contenu Markdown</label>
+              <textarea
+                id="proposal-content"
+                rows="18"
+                value=${form.contentMarkdown}
+                onInput=${handleInputChange('contentMarkdown')}
+                placeholder="# Mon article\n\nCommence ton histoire ici..."
+                class=${[
+                  'min-h-[340px] w-full rounded-2xl border bg-slate-900/80 p-4 font-mono text-sm leading-relaxed text-slate-100 focus:outline-none focus:ring-2',
+                  formErrors.contentMarkdown
+                    ? 'border-rose-400/60 focus:border-rose-400 focus:ring-rose-300'
+                    : 'border-slate-700 focus:border-amber-400 focus:ring-amber-300',
+                ].join(' ')}
+              ></textarea>
+              ${formErrors.contentMarkdown
+                ? html`<p class="text-xs text-rose-300">${formErrors.contentMarkdown}</p>`
+                : html`<p class="text-xs text-slate-400">Ton texte peut inclure des titres, listes, blocs de code et citations.</p>`}
+            </div>
+            <div class="space-y-3">
+              <div class="flex items-center justify-between">
+                <h2 class="text-base font-semibold text-white">Aperçu</h2>
+                <span class="text-xs uppercase tracking-widest text-slate-500">Markdown → HTML</span>
+              </div>
+              <div
+                class="prose prose-invert max-w-none rounded-2xl border border-slate-800/70 bg-slate-900/70 p-6 text-sm leading-relaxed shadow-inner"
+              >
+                <div dangerouslySetInnerHTML=${{ __html: previewHtml }}></div>
+              </div>
+            </div>
+          </div>
+          <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div class="inline-flex items-center gap-2 text-xs text-slate-400">
+              <${AlertCircle} class="h-4 w-4 text-amber-300" aria-hidden="true" />
+              En envoyant ta proposition, tu confirmes être l’auteur·ice du contenu partagé.
+            </div>
+            <button
+              type="submit"
+              class="inline-flex items-center justify-center gap-2 rounded-2xl border border-amber-400/60 bg-amber-500/10 px-6 py-3 text-sm font-semibold uppercase tracking-wide text-amber-100 transition hover:bg-amber-500/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300 disabled:cursor-not-allowed disabled:opacity-60"
+              disabled=${status.submitting}
+            >
+              ${submitButtonLabel}
+            </button>
+          </div>
+        </form>
+      </div>
+    </section>
+  `;
+};

--- a/public/scripts/pages/blog.js
+++ b/public/scripts/pages/blog.js
@@ -1,4 +1,4 @@
-import { html, useCallback, useEffect, useMemo, useRef, useState } from '../core/deps.js';
+import { html, useCallback, useEffect, useMemo, useRef, useState, Sparkles } from '../core/deps.js';
 
 const formatDate = (isoString) => {
   if (!isoString) {
@@ -300,6 +300,17 @@ export const BlogPage = ({ params = {} }) => {
     setSelectedTags([]);
   }, []);
 
+  const handleOpenProposal = useCallback(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    if (window.location.hash !== '#/blog/proposer') {
+      window.location.hash = '#/blog/proposer';
+    } else {
+      window.dispatchEvent(new HashChangeEvent('hashchange'));
+    }
+  }, []);
+
   return html`
     <section class="blog-page space-y-10 px-4 pb-16">
       <header class="mx-auto flex max-w-6xl flex-col gap-6 rounded-3xl border border-slate-800/80 bg-slate-950/70 p-8 shadow-xl">
@@ -313,39 +324,49 @@ export const BlogPage = ({ params = {} }) => {
             recherche et les filtres pour retrouver facilement les sujets qui vous intéressent.
           </p>
         </div>
-        <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-          <div class="relative w-full sm:max-w-sm">
-            <svg
-              class="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="2"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            >
-              <circle cx="11" cy="11" r="7"></circle>
-              <line x1="20" y1="20" x2="16.65" y2="16.65"></line>
-            </svg>
-            <input
-              type="search"
-              value=${searchTerm}
-              onInput=${handleSearchChange}
-              placeholder="Rechercher un article..."
-              class="w-full rounded-xl border border-slate-700 bg-slate-900/80 py-2 pl-9 pr-3 text-sm text-white placeholder:text-slate-500 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-300"
-            />
+        <div class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+          <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:gap-3">
+            <div class="relative w-full sm:max-w-sm">
+              <svg
+                class="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <circle cx="11" cy="11" r="7"></circle>
+                <line x1="20" y1="20" x2="16.65" y2="16.65"></line>
+              </svg>
+              <input
+                type="search"
+                value=${searchTerm}
+                onInput=${handleSearchChange}
+                placeholder="Rechercher un article..."
+                class="w-full rounded-xl border border-slate-700 bg-slate-900/80 py-2 pl-9 pr-3 text-sm text-white placeholder:text-slate-500 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-300"
+              />
+            </div>
+            ${hasActiveFilters
+              ? html`
+                  <button
+                    type="button"
+                    class="inline-flex items-center justify-center rounded-xl border border-amber-400/60 bg-amber-500/10 px-4 py-2 text-sm font-medium text-amber-200 transition hover:bg-amber-500/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300"
+                    onClick=${handleResetFilters}
+                  >
+                    Réinitialiser les filtres
+                  </button>
+                `
+              : null}
           </div>
-          ${hasActiveFilters
-            ? html`
-                <button
-                  type="button"
-                  class="inline-flex items-center justify-center rounded-xl border border-amber-400/60 bg-amber-500/10 px-4 py-2 text-sm font-medium text-amber-200 transition hover:bg-amber-500/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300"
-                  onClick=${handleResetFilters}
-                >
-                  Réinitialiser les filtres
-                </button>
-              `
-            : null}
+          <button
+            type="button"
+            onClick=${() => handleOpenProposal()}
+            class="inline-flex items-center justify-center gap-2 self-start rounded-xl border border-amber-400/60 bg-amber-500/10 px-4 py-2 text-sm font-semibold text-amber-100 shadow-sm transition hover:bg-amber-500/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300"
+          >
+            <${Sparkles} class="h-4 w-4" aria-hidden="true" />
+            Proposer un article
+          </button>
         </div>
         ${tagOptions.length > 0
           ? html`

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import VoiceActivityRepository from './services/VoiceActivityRepository';
 import ListenerStatsService from './services/ListenerStatsService';
 import BlogRepository from './services/BlogRepository';
 import BlogService from './services/BlogService';
+import BlogProposalService from './services/BlogProposalService';
 import DailyArticleService from './services/DailyArticleService';
 import KaldiTranscriptionService from './services/KaldiTranscriptionService';
 
@@ -98,6 +99,16 @@ void blogService.initialize().catch((error) => {
   console.error('BlogService initialization failed', error);
 });
 
+const blogProposalService = new BlogProposalService({
+  proposalsDirectory: path.resolve(__dirname, '..', 'content', 'blog', 'proposals'),
+  repository: blogRepository,
+  blogService,
+});
+
+void blogProposalService.initialize().catch((error) => {
+  console.error('BlogProposalService initialization failed', error);
+});
+
 const dailyArticleService = new DailyArticleService({
   config,
   blogRepository,
@@ -137,6 +148,7 @@ const appServer = new AppServer({
   listenerStatsService,
   blogRepository,
   blogService,
+  blogProposalService,
 });
 appServer.start();
 

--- a/src/services/BlogProposalService.ts
+++ b/src/services/BlogProposalService.ts
@@ -1,0 +1,302 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { randomUUID } from 'crypto';
+import BlogRepository from './BlogRepository';
+import BlogService from './BlogService';
+
+export interface BlogProposalServiceOptions {
+  proposalsDirectory?: string | null;
+  repository?: BlogRepository | null;
+  blogService?: BlogService | null;
+}
+
+export interface SubmitBlogProposalInput {
+  title: string;
+  slug?: string | null;
+  excerpt?: string | null;
+  contentMarkdown: string;
+  coverImageUrl?: string | null;
+  tags?: string[] | null;
+  seoDescription?: string | null;
+  authorName?: string | null;
+  authorContact?: string | null;
+}
+
+export interface BlogProposalRecord {
+  title: string;
+  slug: string;
+  excerpt: string | null;
+  contentMarkdown: string;
+  coverImageUrl: string | null;
+  tags: string[];
+  seoDescription: string | null;
+  authorName: string | null;
+  authorContact: string | null;
+  reference: string;
+  submittedAt: Date;
+}
+
+export interface SubmitBlogProposalResult {
+  slug: string;
+  reference: string;
+  submittedAt: string;
+}
+
+export class BlogProposalError extends Error {
+  readonly code: 'VALIDATION_ERROR' | 'CONFLICT' | 'UNAVAILABLE' | 'INTERNAL_ERROR';
+
+  readonly details: Record<string, string> | null;
+
+  constructor(
+    code: 'VALIDATION_ERROR' | 'CONFLICT' | 'UNAVAILABLE' | 'INTERNAL_ERROR',
+    message: string,
+    details: Record<string, string> | null = null,
+  ) {
+    super(message);
+    this.name = 'BlogProposalError';
+    this.code = code;
+    this.details = details;
+  }
+}
+
+const MAX_TITLE_LENGTH = 160;
+const MAX_SLUG_LENGTH = 120;
+const MAX_EXCERPT_LENGTH = 320;
+const MAX_SEO_DESCRIPTION_LENGTH = 320;
+const MAX_AUTHOR_FIELD_LENGTH = 160;
+const MAX_TAGS = 10;
+const MAX_MARKDOWN_LENGTH = 50_000;
+
+const normalizeLineEndings = (value: string): string => value.replace(/\r\n?/g, '\n');
+
+const slugify = (value: string): string => {
+  const normalized = value
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, MAX_SLUG_LENGTH);
+  return normalized || `proposition-${Date.now()}`;
+};
+
+const normalizeTags = (tags: string[]): string[] => {
+  const unique = new Set<string>();
+  for (const rawTag of tags) {
+    if (typeof rawTag !== 'string') {
+      continue;
+    }
+    const trimmed = rawTag.trim();
+    if (!trimmed) {
+      continue;
+    }
+    unique.add(trimmed);
+    if (unique.size >= MAX_TAGS) {
+      break;
+    }
+  }
+  return Array.from(unique);
+};
+
+const isValidUrl = (value: string): boolean => {
+  try {
+    const url = new URL(value);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+};
+
+export default class BlogProposalService {
+  private readonly proposalsDirectory: string | null;
+
+  private readonly repository: BlogRepository | null;
+
+  private readonly blogService: BlogService | null;
+
+  private initialized = false;
+
+  constructor(options: BlogProposalServiceOptions) {
+    this.proposalsDirectory = options.proposalsDirectory ?? null;
+    this.repository = options.repository ?? null;
+    this.blogService = options.blogService ?? null;
+  }
+
+  async initialize(): Promise<void> {
+    if (this.initialized) {
+      return;
+    }
+
+    if (this.repository) {
+      await this.repository.ensureSchema();
+    }
+
+    if (this.proposalsDirectory) {
+      try {
+        await fs.mkdir(this.proposalsDirectory, { recursive: true });
+      } catch (error) {
+        console.warn('BlogProposalService: unable to create proposals directory', error);
+      }
+    }
+
+    this.initialized = true;
+  }
+
+  async submitProposal(input: SubmitBlogProposalInput): Promise<SubmitBlogProposalResult> {
+    await this.initialize();
+
+    const errors: Record<string, string> = {};
+
+    const title = typeof input.title === 'string' ? input.title.trim() : '';
+    if (!title) {
+      errors.title = 'Le titre est obligatoire.';
+    } else if (title.length > MAX_TITLE_LENGTH) {
+      errors.title = `Le titre ne peut pas dépasser ${MAX_TITLE_LENGTH} caractères.`;
+    }
+
+    const providedSlug = typeof input.slug === 'string' ? input.slug.trim() : '';
+    if (providedSlug && !/^[-a-zA-Z0-9_]+$/.test(providedSlug)) {
+      errors.slug = 'Le lien ne peut contenir que des lettres, chiffres, tirets ou underscores.';
+    } else if (providedSlug.length > MAX_SLUG_LENGTH) {
+      errors.slug = `Le lien ne peut pas dépasser ${MAX_SLUG_LENGTH} caractères.`;
+    }
+
+    const excerpt = typeof input.excerpt === 'string' ? input.excerpt.trim() : '';
+    if (excerpt.length > MAX_EXCERPT_LENGTH) {
+      errors.excerpt = `L’accroche ne peut pas dépasser ${MAX_EXCERPT_LENGTH} caractères.`;
+    }
+
+    const seoDescription = typeof input.seoDescription === 'string' ? input.seoDescription.trim() : '';
+    if (seoDescription.length > MAX_SEO_DESCRIPTION_LENGTH) {
+      errors.seoDescription = `La description SEO ne peut pas dépasser ${MAX_SEO_DESCRIPTION_LENGTH} caractères.`;
+    }
+
+    const contentMarkdown = normalizeLineEndings(input.contentMarkdown ?? '');
+    if (!contentMarkdown.trim()) {
+      errors.contentMarkdown = 'Le contenu en Markdown est obligatoire.';
+    } else if (contentMarkdown.length > MAX_MARKDOWN_LENGTH) {
+      errors.contentMarkdown = `Le contenu est trop long (limite de ${MAX_MARKDOWN_LENGTH} caractères).`;
+    }
+
+    const coverImageUrlRaw = typeof input.coverImageUrl === 'string' ? input.coverImageUrl.trim() : '';
+    if (coverImageUrlRaw && !isValidUrl(coverImageUrlRaw)) {
+      errors.coverImageUrl = 'Le lien de l’illustration doit être une URL valide.';
+    }
+
+    const authorNameRaw = typeof input.authorName === 'string' ? input.authorName.trim() : '';
+    if (authorNameRaw.length > MAX_AUTHOR_FIELD_LENGTH) {
+      errors.authorName = `Le nom ou pseudo ne peut pas dépasser ${MAX_AUTHOR_FIELD_LENGTH} caractères.`;
+    }
+
+    const authorContactRaw = typeof input.authorContact === 'string' ? input.authorContact.trim() : '';
+    if (authorContactRaw.length > MAX_AUTHOR_FIELD_LENGTH) {
+      errors.authorContact = `Le contact ne peut pas dépasser ${MAX_AUTHOR_FIELD_LENGTH} caractères.`;
+    }
+
+    let tagsInput: string[] = [];
+    if (Array.isArray(input.tags)) {
+      tagsInput = input.tags;
+    }
+    const tags = normalizeTags(tagsInput);
+
+    if (Object.keys(errors).length > 0) {
+      throw new BlogProposalError('VALIDATION_ERROR', 'Certaines informations sont manquantes ou invalides.', errors);
+    }
+
+    const slugBase = providedSlug ? slugify(providedSlug) : slugify(title);
+    const slug = await this.resolveUniqueSlug(slugBase);
+
+    const record: BlogProposalRecord = {
+      title,
+      slug,
+      excerpt: excerpt || null,
+      contentMarkdown,
+      coverImageUrl: coverImageUrlRaw || null,
+      tags,
+      seoDescription: seoDescription || null,
+      authorName: authorNameRaw || null,
+      authorContact: authorContactRaw || null,
+      reference: randomUUID(),
+      submittedAt: new Date(),
+    };
+
+    if (this.repository) {
+      try {
+        await this.repository.createProposal(record);
+      } catch (error) {
+        console.error('BlogProposalService: unable to persist proposal in database', error);
+        throw new BlogProposalError('INTERNAL_ERROR', "Impossible d’enregistrer la proposition dans la base de données.");
+      }
+    } else if (this.proposalsDirectory) {
+      const fileName = `${record.submittedAt.getTime()}-${record.slug}.json`;
+      const safeFileName = fileName.replace(/[^a-zA-Z0-9-_\.]/g, '_');
+      const targetPath = path.join(this.proposalsDirectory, safeFileName);
+      try {
+        await fs.writeFile(targetPath, JSON.stringify({ ...record, submittedAt: record.submittedAt.toISOString() }, null, 2), {
+          encoding: 'utf-8',
+        });
+      } catch (error) {
+        console.error('BlogProposalService: unable to persist proposal on filesystem', error);
+        throw new BlogProposalError('INTERNAL_ERROR', "Impossible d’enregistrer la proposition sur le serveur.");
+      }
+    } else {
+      throw new BlogProposalError('UNAVAILABLE', 'Aucun espace de stockage n’est configuré pour les propositions.');
+    }
+
+    return {
+      slug: record.slug,
+      reference: record.reference,
+      submittedAt: record.submittedAt.toISOString(),
+    };
+  }
+
+  private async resolveUniqueSlug(baseSlug: string): Promise<string> {
+    let candidate = baseSlug;
+    let attempt = 0;
+    while (await this.slugExists(candidate)) {
+      attempt += 1;
+      if (attempt > 20) {
+        return `${baseSlug}-${Date.now()}`;
+      }
+      candidate = `${baseSlug}-${attempt}`;
+    }
+    return candidate;
+  }
+
+  private async slugExists(slug: string): Promise<boolean> {
+    if (this.repository) {
+      try {
+        const existingPost = await this.repository.getPostBySlug(slug);
+        if (existingPost) {
+          return true;
+        }
+        const existingProposal = await this.repository.getProposalBySlug(slug);
+        if (existingProposal) {
+          return true;
+        }
+      } catch (error) {
+        console.warn('BlogProposalService: unable to verify slug uniqueness with repository', error);
+      }
+    } else if (this.blogService) {
+      try {
+        const post = await this.blogService.getPost(slug);
+        if (post) {
+          return true;
+        }
+      } catch (error) {
+        console.warn('BlogProposalService: unable to verify slug uniqueness with blog service', error);
+      }
+    }
+
+    if (this.proposalsDirectory) {
+      try {
+        const entries = await fs.readdir(this.proposalsDirectory);
+        return entries.some((entry) => entry.endsWith(`${slug}.json`));
+      } catch (error) {
+        console.warn('BlogProposalService: unable to inspect proposals directory for slug uniqueness', error);
+      }
+    }
+
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- add a blog proposal service, repository support and API endpoint to store suggested articles
- expose a dedicated Markdown submission page from the blog with validation, preview and illustration support
- update the client router and shared dependencies to include the proposal route and Markdown rendering

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1a094a9188324881cb465ff8dcae3