### PR TITLE
Ensure Kaldi transcripts persist and improve logging

### DIFF
--- a/src/discord/DiscordAudioBridge.ts
+++ b/src/discord/DiscordAudioBridge.ts
@@ -529,7 +529,10 @@ export default class DiscordAudioBridge {
       this.speakerTracker.handleSpeakingEnd(userId);
       this.mixer.removeSource(userId);
       void this.transcriptionService?.finalizeSession(userId).catch((error) => {
-        console.warn('Failed to finalize transcription session on speaking end', error);
+        console.error('Failed to finalize transcription session on speaking end', {
+          userId,
+          error,
+        });
       });
     });
 
@@ -620,7 +623,10 @@ export default class DiscordAudioBridge {
         this.mixer.removeSource(userId);
         this.speakerTracker.handleSpeakingEnd(userId);
         void this.transcriptionService?.finalizeSession(userId).catch((error) => {
-          console.warn('Failed to finalize transcription session during cleanup', error);
+          console.error('Failed to finalize transcription session during cleanup', {
+            userId,
+            error,
+          });
         });
         console.log('Cleaned resources for user', userId);
       };
@@ -1006,7 +1012,10 @@ export default class DiscordAudioBridge {
         this.mixer.removeSource(userId);
         this.speakerTracker.handleSpeakingEnd(userId);
         void this.transcriptionService?.finalizeSession(userId).catch((error) => {
-          console.warn('Failed to finalize transcription session during manual cleanup', error);
+          console.error('Failed to finalize transcription session during manual cleanup', {
+            userId,
+            error,
+          });
         });
       }
       return;
@@ -1015,7 +1024,10 @@ export default class DiscordAudioBridge {
     this.mixer.removeSource(userId);
     this.speakerTracker.handleSpeakingEnd(userId);
     void this.transcriptionService?.finalizeSession(userId).catch((error) => {
-      console.warn('Failed to finalize transcription session during passive cleanup', error);
+      console.error('Failed to finalize transcription session during passive cleanup', {
+        userId,
+        error,
+      });
     });
   }
 }


### PR DESCRIPTION
## Summary
- ensure Kaldi transcription sessions always attempt to persist aggregated transcripts even if a session closes unexpectedly
- add contextual error logging and real-time transcript logging for Kaldi FR interactions
- surface transcription finalization failures in Discord bridge logs with user metadata

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68e1a5cc4e4083248c7374dfb3bb3553