### PR TITLE
Adjust service worker caching strategy for fresher updates

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,5 @@
-const CACHE_NAME = 'libre-antenne-pwa-v1';
+const CACHE_VERSION = 'v2';
+const CACHE_NAME = `libre-antenne-pwa-${CACHE_VERSION}`;
 const PRECACHE_URLS = [
   '/',
   '/index.html',
@@ -35,6 +36,10 @@ self.addEventListener('fetch', (event) => {
     return;
   }
 
+  if (request.cache === 'only-if-cached' && request.mode !== 'same-origin') {
+    return;
+  }
+
   const url = new URL(request.url);
 
   if (url.origin === self.location.origin) {
@@ -43,35 +48,12 @@ self.addEventListener('fetch', (event) => {
     }
 
     if (request.mode === 'navigate') {
-      event.respondWith(
-        fetch(request)
-          .then((response) => {
-            const copy = response.clone();
-            caches.open(CACHE_NAME).then((cache) => cache.put(request, copy));
-            return response;
-          })
-          .catch(() =>
-            caches.match(request).then((cached) => cached || caches.match('/offline.html'))
-          )
-      );
+      event.respondWith(networkFirst(request, { fallbackToOffline: true }));
       return;
     }
 
-    event.respondWith(
-      caches.match(request).then((cached) => {
-        if (cached) {
-          return cached;
-        }
-
-        return fetch(request)
-          .then((response) => {
-            const copy = response.clone();
-            caches.open(CACHE_NAME).then((cache) => cache.put(request, copy));
-            return response;
-          })
-          .catch(() => caches.match('/offline.html'));
-      })
-    );
+    const shouldFallbackToOffline = request.destination === 'document';
+    event.respondWith(networkFirst(request, { fallbackToOffline: shouldFallbackToOffline }));
     return;
   }
 
@@ -79,3 +61,46 @@ self.addEventListener('fetch', (event) => {
     fetch(request).catch(() => caches.match('/offline.html'))
   );
 });
+
+function shouldCacheResponse(response) {
+  if (!response || !response.ok) {
+    return false;
+  }
+
+  const cacheControl = response.headers.get('Cache-Control');
+  if (cacheControl && /no-store|no-cache|private/i.test(cacheControl)) {
+    return false;
+  }
+
+  return response.type === 'basic' || response.type === 'cors';
+}
+
+async function networkFirst(request, { fallbackToOffline = false } = {}) {
+  const cache = await caches.open(CACHE_NAME);
+
+  try {
+    const response = await fetch(request);
+    if (shouldCacheResponse(response)) {
+      await cache.put(request, response.clone());
+    }
+    return response;
+  } catch (error) {
+    const cachedResponse = await cache.match(request);
+    if (cachedResponse) {
+      return cachedResponse;
+    }
+
+    if (fallbackToOffline) {
+      const offline = await cache.match('/offline.html');
+      if (offline) {
+        return offline;
+      }
+    }
+
+    return new Response('', {
+      status: 503,
+      statusText: 'Service Unavailable',
+      headers: { 'Cache-Control': 'no-store' },
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- switch the service worker to a network-first strategy so new assets are fetched before falling back to cache
- bump the offline cache version and avoid storing responses that forbid caching to limit staleness issues

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e25e27be388324a390c08bd13864a1