### PR TITLE
Fix profile page overflow on mobile devices

### DIFF
--- a/public/scripts/components/index.js
+++ b/public/scripts/components/index.js
@@ -3027,7 +3027,7 @@ const ProfileVoiceTranscriptionsCard = ({ userId }) => {
                 key=${entry.transcriptionId || `${entry.channelId}-${entry.timestamp}`}
                 class="rounded-2xl border border-white/10 bg-black/30 px-4 py-3 text-sm text-slate-200"
               >
-                <p class="font-medium text-white">${content || 'Transcription vide'}</p>
+                <p class="break-words font-medium text-white">${content || 'Transcription vide'}</p>
                 ${timestamp
                   ? html`<p class="text-xs text-slate-400">
                       ${formatDateTimeLabel(timestamp, { includeDate: true, includeSeconds: true })}
@@ -3067,7 +3067,7 @@ const ProfileMessagesCard = ({ messageEvents = [] }) => {
                 key=${event.messageId || `${index}-${event.timestampMs}`}
                 class="rounded-2xl border border-white/10 bg-black/30 px-4 py-3 text-sm text-slate-200"
               >
-                <p class="font-medium text-white">${content || 'Message sans contenu'}</p>
+                <p class="break-words font-medium text-white">${content || 'Message sans contenu'}</p>
                 ${timestamp
                   ? html`<p class="text-xs text-slate-400">
                       ${formatDateTimeLabel(timestamp, { includeDate: true, includeSeconds: true })}

--- a/public/scripts/pages/profile.js
+++ b/public/scripts/pages/profile.js
@@ -217,7 +217,7 @@ const ProfilePage = ({ params, onNavigateHome, onUpdateRange }) => {
             </button>
           </section>`
         : html`
-            <div class="mt-6 grid gap-8">
+            <div class="mt-6 grid grid-cols-1 gap-8">
               <${ProfileIdentityCard} profile=${data?.profile ?? null} userId=${userId} />
 
               <section class="rounded-3xl border border-white/10 bg-white/5 p-6 shadow-xl shadow-slate-950/40 backdrop-blur-xl">


### PR DESCRIPTION
## Summary
- ensure the profile layout grid defines a single responsive column to prevent auto-sized overflow
- allow long transcription and message text to wrap inside their cards so wide content stays within the viewport

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e26626ceec83248a257dd41a008cbb