### PR TITLE
Add basic auth admin API for member moderation and article control

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,23 @@ SHOP_COINGATE_CALLBACK_URL=https://example.com/shop/callback
 
 Leaving these variables undefined disables the CoinGate (and thus SEPA transfer) option entirely.
 
+### Interface administrateur
+
+Un panneau minimaliste est disponible à l'adresse `/admin`. Il est protégé par une authentification HTTP basique ; définissez les variables d'environnement suivantes pour l'activer :
+
+```env
+ADMIN_USERNAME=alice
+ADMIN_PASSWORD=motdepasseSuperSecret
+```
+
+Une fois authentifié, ce point d'entrée expose plusieurs actions :
+
+- récupérer un état synthétique du service (auditeurs en direct, orateurs suivis, configuration OpenAI, membres masqués, prochaine génération d'article) ;
+- masquer la fiche d'un membre (`POST /admin/members/{userId}/hide` avec un champ optionnel `idea`) ou la ré-afficher (`DELETE /admin/members/{userId}/hide`) ;
+- déclencher manuellement la génération de l'article quotidien (`POST /admin/articles/daily`).
+
+Les profils masqués ne sont plus renvoyés par les API publiques et leur page dédiée affiche un message de confidentialité.
+
 ## Statistiques et confidentialité
 
 Ces données sont calculées à partir de l’activité vocale et textuelle enregistrée.

--- a/src/config.ts
+++ b/src/config.ts
@@ -86,6 +86,11 @@ export interface KaldiConfig {
   enabled: boolean;
 }
 
+export interface AdminConfig {
+  username: string | null;
+  password: string | null;
+}
+
 export interface Config {
   botToken: string;
   guildId?: string;
@@ -112,6 +117,7 @@ export interface Config {
   twitterSite?: string;
   twitterCreator?: string;
   kaldi: KaldiConfig;
+  admin: AdminConfig;
 }
 
 const config: Config = {
@@ -210,6 +216,17 @@ const config: Config = {
     port: parseInteger(process.env.KALDI_PORT, 2700),
     sampleRate: parseInteger(process.env.KALDI_SAMPLE_RATE, 16000),
     enabled: process.env.KALDI_ENABLED !== 'false',
+  },
+  admin: {
+    username: (() => {
+      const value = process.env.ADMIN_USERNAME ?? '';
+      const trimmed = value.trim();
+      return trimmed.length > 0 ? trimmed : null;
+    })(),
+    password: (() => {
+      const value = process.env.ADMIN_PASSWORD ?? '';
+      return value.length > 0 ? value : null;
+    })(),
   },
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import BlogProposalService from './services/BlogProposalService';
 import DailyArticleService from './services/DailyArticleService';
 import KaldiTranscriptionService from './services/KaldiTranscriptionService';
 import UserPersonaService from './services/UserPersonaService';
+import AdminService from './services/AdminService';
 
 const mixer = new AudioMixer({
   frameBytes: config.audio.frameBytes,
@@ -122,6 +123,14 @@ const userPersonaService = new UserPersonaService({
   voiceActivityRepository,
 });
 
+const adminService = new AdminService({
+  storageDirectory: path.resolve(__dirname, '..', 'content', 'admin'),
+});
+
+void adminService.initialize().catch((error) => {
+  console.error('AdminService initialization failed', error);
+});
+
 const discordBridge = new DiscordAudioBridge({
   config,
   mixer,
@@ -155,6 +164,8 @@ const appServer = new AppServer({
   blogRepository,
   blogService,
   blogProposalService,
+  dailyArticleService,
+  adminService,
 });
 appServer.start();
 

--- a/src/services/AdminService.ts
+++ b/src/services/AdminService.ts
@@ -1,0 +1,153 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+export interface HiddenMemberRecord {
+  userId: string;
+  idea: string | null;
+  hiddenAt: string;
+}
+
+interface AdminServiceOptions {
+  storageDirectory: string;
+  hiddenMembersFileName?: string;
+}
+
+export default class AdminService {
+  private readonly storageDirectory: string;
+
+  private readonly hiddenMembersFilePath: string;
+
+  private hiddenMembers: Map<string, HiddenMemberRecord> = new Map();
+
+  private initialized = false;
+
+  private initializing: Promise<void> | null = null;
+
+  constructor({ storageDirectory, hiddenMembersFileName = 'hidden-members.json' }: AdminServiceOptions) {
+    this.storageDirectory = storageDirectory;
+    this.hiddenMembersFilePath = path.join(this.storageDirectory, hiddenMembersFileName);
+  }
+
+  public async initialize(): Promise<void> {
+    await this.ensureInitialized();
+  }
+
+  public async listHiddenMembers(): Promise<HiddenMemberRecord[]> {
+    await this.ensureInitialized();
+    return Array.from(this.hiddenMembers.values()).sort((a, b) => a.hiddenAt.localeCompare(b.hiddenAt));
+  }
+
+  public async getHiddenMemberIds(): Promise<Set<string>> {
+    const members = await this.listHiddenMembers();
+    return new Set(members.map((entry) => entry.userId));
+  }
+
+  public async isMemberHidden(userId: string): Promise<boolean> {
+    if (!userId) {
+      return false;
+    }
+    await this.ensureInitialized();
+    return this.hiddenMembers.has(userId);
+  }
+
+  public async hideMember(userId: string, idea?: string | null): Promise<HiddenMemberRecord> {
+    const normalizedId = this.normalizeUserId(userId);
+    if (!normalizedId) {
+      throw new Error('USER_ID_REQUIRED');
+    }
+
+    await this.ensureInitialized();
+
+    const sanitizedIdea = this.normalizeIdea(idea);
+    const record: HiddenMemberRecord = {
+      userId: normalizedId,
+      idea: sanitizedIdea,
+      hiddenAt: new Date().toISOString(),
+    };
+
+    this.hiddenMembers.set(normalizedId, record);
+    await this.persist();
+    return record;
+  }
+
+  public async unhideMember(userId: string): Promise<boolean> {
+    const normalizedId = this.normalizeUserId(userId);
+    if (!normalizedId) {
+      throw new Error('USER_ID_REQUIRED');
+    }
+
+    await this.ensureInitialized();
+
+    const existed = this.hiddenMembers.delete(normalizedId);
+    if (existed) {
+      await this.persist();
+    }
+
+    return existed;
+  }
+
+  private normalizeIdea(value: string | null | undefined): string | null {
+    if (typeof value !== 'string') {
+      return null;
+    }
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+
+  private normalizeUserId(value: string | null | undefined): string | null {
+    if (typeof value !== 'string') {
+      return null;
+    }
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+
+  private async ensureInitialized(): Promise<void> {
+    if (this.initialized) {
+      return;
+    }
+    if (!this.initializing) {
+      this.initializing = this.loadFromDisk();
+    }
+    await this.initializing;
+  }
+
+  private async loadFromDisk(): Promise<void> {
+    try {
+      await fs.mkdir(this.storageDirectory, { recursive: true });
+    } catch (error) {
+      console.warn('AdminService: unable to ensure storage directory', error);
+    }
+
+    try {
+      const raw = await fs.readFile(this.hiddenMembersFilePath, 'utf8');
+      const parsed = JSON.parse(raw) as HiddenMemberRecord[];
+      if (Array.isArray(parsed)) {
+        this.hiddenMembers = new Map(
+          parsed
+            .map((entry) => ({
+              ...entry,
+              userId: this.normalizeUserId(entry?.userId) ?? '',
+              idea: this.normalizeIdea(entry?.idea ?? null),
+              hiddenAt: typeof entry?.hiddenAt === 'string' ? entry.hiddenAt : new Date().toISOString(),
+            }))
+            .filter((entry) => entry.userId.length > 0)
+            .map((entry) => [entry.userId, entry]),
+        );
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException)?.code !== 'ENOENT') {
+        console.warn('AdminService: failed to read hidden member registry', error);
+      }
+      this.hiddenMembers = new Map();
+    } finally {
+      this.initialized = true;
+      this.initializing = null;
+    }
+  }
+
+  private async persist(): Promise<void> {
+    const payload = JSON.stringify(await this.listHiddenMembers(), null, 2);
+    await fs.writeFile(this.hiddenMembersFilePath, `${payload}\n`, 'utf8');
+  }
+}


### PR DESCRIPTION
## Summary
- add an AdminService that persists hidden member metadata and wire it into the server bootstrap and configuration
- expose basic-auth protected /admin endpoints to view service status, hide or reveal member profiles, and trigger daily article generation
- update member/profile APIs to respect hidden users and extend the daily article service with manual execution, status reporting, and scheduling telemetry
- document the admin interface environment variables and add a storage directory placeholder for hidden member data

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2af639da8832484b7c9d864618b0d