### PR TITLE
Fix persona schema required fields

### DIFF
--- a/src/services/UserPersonaService.ts
+++ b/src/services/UserPersonaService.ts
@@ -43,7 +43,7 @@ const MAX_MESSAGE_FETCH = 200;
 const PERSONA_ITEM_SCHEMA = {
   type: 'object',
   additionalProperties: false,
-  required: ['title', 'detail', 'confidence'],
+  required: ['title', 'detail', 'confidence', 'evidence'],
   properties: {
     title: { type: 'string' },
     detail: { type: 'string' },


### PR DESCRIPTION
## Summary
- ensure the persona item schema lists the evidence property in the required keys to satisfy the OpenAI response format validator

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2bad9e4748324a6e9e6b69e3b3750