### PR TITLE
Ensure leaderboard search uses absolute ranking

### DIFF
--- a/public/scripts/pages/classements.js
+++ b/public/scripts/pages/classements.js
@@ -392,7 +392,8 @@ const ClassementsPage = ({ params = {} }) => {
     return html`
       <${Fragment}>
         ${leaders.slice(0, 100).map((leader, index) => {
-          const rank = index + 1;
+          const candidateRank = Number(leader?.rank ?? leader?.absoluteRank);
+          const rank = Number.isFinite(candidateRank) && candidateRank > 0 ? Math.floor(candidateRank) : index + 1;
           const style = rank <= 3 ? topThreeStyles[rank - 1] : null;
           const highlight = style ? style.highlight : 'border-white/5 bg-slate-900/50';
           const accent = style ? style.accent : 'from-transparent to-transparent';


### PR DESCRIPTION
## Summary
- compute absolute hype ranks in the repository query and expose them to consumers
- update the leaderboard service to keep ranks absolute when sorting or filtering
- render leaderboard cards with the provided rank instead of the filtered index

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2bdde74b083249b4cfae71f292b27