### PR TITLE
Restore hype leaderboard data using cached snapshots

### DIFF
--- a/src/services/VoiceActivityRepository.ts
+++ b/src/services/VoiceActivityRepository.ts
@@ -257,8 +257,15 @@ export interface HypeLeaderboardSnapshotOptions {
 export interface HypeLeaderboardSnapshotEntry {
   userId: string;
   rank: number;
+  absoluteRank?: number | null;
+  displayName?: string | null;
+  username?: string | null;
   sessions: number;
+  arrivalEffect?: number | null;
+  departureEffect?: number | null;
+  retentionMinutes?: number | null;
   activityScore: number;
+  schRaw?: number | null;
   schScoreNorm: number;
 }
 


### PR DESCRIPTION
## Summary
- fall back to cached leaderboard snapshots when the live database query fails
- enrich persisted snapshot entries with display and metric fields needed to rebuild the ranking
- reuse snapshot data to repopulate in-memory caches so the classement page keeps working during outages

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2e32086e083249b94c99498625712