### PR TITLE
Refactor routing to use History API paths

### DIFF
--- a/public/scripts/pages/blog-proposal.js
+++ b/public/scripts/pages/blog-proposal.js
@@ -107,7 +107,7 @@ const inputClasses = (hasError) =>
       : 'border-slate-700 focus:border-amber-400 focus:ring-amber-300',
   ].join(' ');
 
-export const BlogProposalPage = () => {
+export const BlogProposalPage = ({ onNavigateToBlog }) => {
   const [form, setForm] = useState(initialFormState);
   const [formErrors, setFormErrors] = useState({});
   const [status, setStatus] = useState({ submitting: false, success: false, message: '', reference: null });
@@ -227,14 +227,22 @@ export const BlogProposalPage = () => {
     [form, tagList],
   );
 
-  const handleBackToBlog = useCallback((event) => {
-    event.preventDefault();
-    if (window.location.hash !== '#/blog') {
-      window.location.hash = '#/blog';
-    } else {
-      window.dispatchEvent(new HashChangeEvent('hashchange'));
-    }
-  }, []);
+  const handleBackToBlog = useCallback(
+    (event) => {
+      event.preventDefault();
+      if (typeof onNavigateToBlog === 'function') {
+        onNavigateToBlog();
+        return;
+      }
+      if (typeof window !== 'undefined' && typeof window.history?.pushState === 'function') {
+        window.history.pushState({ route: { name: 'blog', params: {} } }, '', '/blog');
+        const popEvent =
+          typeof window.PopStateEvent === 'function' ? new PopStateEvent('popstate') : new Event('popstate');
+        window.dispatchEvent(popEvent);
+      }
+    },
+    [onNavigateToBlog],
+  );
 
   const submitButtonLabel = status.submitting ? 'Envoi en cours…' : 'Envoyer ma proposition';
 
@@ -243,7 +251,7 @@ export const BlogProposalPage = () => {
       <div class="mx-auto flex w-full max-w-5xl flex-col gap-6">
         <div class="flex items-center gap-3 text-sm">
           <a
-            href="#/blog"
+            href="/blog"
             onClick=${handleBackToBlog}
             class="inline-flex items-center gap-2 rounded-full border border-slate-700 bg-slate-900/70 px-4 py-2 text-slate-200 transition hover:border-amber-400/60 hover:text-amber-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300"
           >

--- a/public/scripts/pages/shop.js
+++ b/public/scripts/pages/shop.js
@@ -27,13 +27,13 @@ const parseCheckoutFeedback = () => {
   }
 
   try {
-    const hash = window.location.hash || '';
-    const [path = '', query = ''] = hash.split('?');
-    if (!path.toLowerCase().includes('boutique')) {
+    const { pathname, search } = window.location;
+    const normalizedPath = typeof pathname === 'string' ? pathname.toLowerCase() : '';
+    if (!['/boutique', '/shop'].includes(normalizedPath)) {
       return null;
     }
 
-    const params = new URLSearchParams(query);
+    const params = new URLSearchParams(search || '');
     const status = (params.get('checkout') || '').toLowerCase();
     if (!status) {
       return null;
@@ -53,7 +53,7 @@ const parseCheckoutFeedback = () => {
     }
 
     if (typeof window.history?.replaceState === 'function') {
-      window.history.replaceState(null, '', '#/boutique');
+      window.history.replaceState({ route: { name: 'shop', params: {} } }, '', '/boutique');
     }
 
     return { type, message };
@@ -110,10 +110,10 @@ export const ShopPage = () => {
     if (typeof window === 'undefined') {
       return { success: '', cancel: '' };
     }
-    const base = `${window.location.origin}${window.location.pathname}${window.location.search}`;
+    const base = new URL('/boutique', window.location.origin);
     return {
-      success: `${base}#/boutique?checkout=success`,
-      cancel: `${base}#/boutique?checkout=cancelled`,
+      success: `${base.href}?checkout=success`,
+      cancel: `${base.href}?checkout=cancelled`,
     };
   }, []);
 


### PR DESCRIPTION
## Summary
- replace hash-based routing with a shared pathname parser and legacy hash normalization
- update the app shell and navigation links to push canonical paths via the History API
- adjust blog, classements, and shop flows to emit crawlable URLs and synchronize query params

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e36926a53c8324a588079055d86852