### PR TITLE
Add SSR prerendering and expand sitemap

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -94,8 +94,9 @@
       <link rel="stylesheet" href="/styles/app.css" />
   </head>
   <body class="min-h-screen bg-slate-950 text-slate-100 antialiased">
-    <div id="app" class="min-h-screen"></div>
+    <div id="app" class="min-h-screen"><!--APP_HTML--></div>
 
+      <!--APP_STATE-->
       <script type="module" src="/scripts/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add HTML placeholders and extend the SEO renderer so prerendered page markup and bootstrap state can be injected
- implement server-side prerender helpers for the home, members, blog, profile and proposal pages and hook them into the Express routes
- expand sitemap generation by adding the blog proposal page and active profile URLs using a new repository helper

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3a7a1362c832490b46eb65693f4b8