### PR TITLE
Implement client hydration bootstrap for SSR pages

### DIFF
--- a/public/scripts/core/deps.js
+++ b/public/scripts/core/deps.js
@@ -1,4 +1,4 @@
-import { h, render, Fragment } from 'https://esm.sh/preact@10.19.2';
+import { h, render, hydrate, Fragment } from 'https://esm.sh/preact@10.19.2';
 import {
   useCallback,
   useEffect,
@@ -53,6 +53,7 @@ const html = htm.bind(h);
 export {
   h,
   render,
+  hydrate,
   Fragment,
   html,
   useCallback,


### PR DESCRIPTION
## Summary
- switch the client to hydrate pre-rendered markup and consume serialized bootstrap state for participants and listener stats
- serialize server-side data for the home and blog routes and embed it in the SEO shell response
- initialize the blog SPA from bootstrap data to avoid redundant fetches for listings and articles

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e52612de988324acb68c30a0418786