### PR TITLE
Fix leaderboard display names defaulting to anonymous

### DIFF
--- a/src/services/HypeLeaderboardService.ts
+++ b/src/services/HypeLeaderboardService.ts
@@ -413,10 +413,16 @@ export default class HypeLeaderboardService {
         const candidateRank = parseRank(entry.absoluteRank) ?? parseRank(entry.rank) ?? index + 1;
         const absoluteRank = Math.max(1, Math.floor(candidateRank));
 
+        const snapshotUsername = this.normalizeString(entry.username);
+        const snapshotDisplayName =
+          this.normalizeString(entry.displayName)
+          ?? snapshotUsername
+          ?? 'Anonyme';
+
         baseLeaders.push({
           userId: entry.userId,
-          displayName: this.normalizeString(entry.displayName) ?? 'Anonyme',
-          username: this.normalizeString(entry.username),
+          displayName: snapshotDisplayName,
+          username: snapshotUsername,
           sessions: toNumber(entry.sessions),
           absoluteRank,
           arrivalEffect: toNumber(entry.arrivalEffect),
@@ -477,10 +483,12 @@ export default class HypeLeaderboardService {
     return leaders.map<EnrichedLeader>((leader, index) => {
       const identity = identities[index];
       const avatarUrl = identity?.avatarUrl ?? null;
-      const displayName = this.normalizeString(leader.displayName)
-        ?? this.normalizeString(identity?.displayName)
-        ?? 'Anonyme';
       const username = this.normalizeString(leader.username) ?? this.normalizeString(identity?.username);
+      const displayName =
+        this.normalizeString(leader.displayName)
+        ?? this.normalizeString(identity?.displayName)
+        ?? username
+        ?? 'Anonyme';
 
       return {
         ...leader,

--- a/src/services/VoiceActivityRepository.ts
+++ b/src/services/VoiceActivityRepository.ts
@@ -2396,9 +2396,8 @@ ${limitClause}`;
           return numeric;
         };
 
-        const displayName = this.normalizeString(row.display_name) ?? 'Anonyme';
-
         const username = this.normalizeString(row.username);
+        const displayName = this.normalizeString(row.display_name) ?? username ?? 'Anonyme';
 
         return {
           userId: String(row.user_id ?? ''),


### PR DESCRIPTION
## Summary
- ensure hype leaderboard rows use usernames before falling back to the anonymous label
- keep usernames when rehydrating leaderboard snapshots so cached data preserves display names

## Testing
- npm run build *(fails: missing local dependency `esbuild` in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e55b9b60f883249d3508b210a016f0