### PR TITLE
Add fallback asset manifest for missing build artifacts

### DIFF
--- a/src/http/SeoRenderer.ts
+++ b/src/http/SeoRenderer.ts
@@ -169,7 +169,13 @@ export default class SeoRenderer {
   }
 
   public updateAssetManifest(manifest: AssetManifest | null): void {
-    this.assetManifest = this.normalizeAssetManifest(manifest);
+    const normalized = this.normalizeAssetManifest(manifest);
+    if (normalized && this.hasUsableAssets(normalized)) {
+      this.assetManifest = normalized;
+      return;
+    }
+
+    this.assetManifest = this.normalizeAssetManifest(this.buildFallbackAssetManifest());
   }
 
   public render(metadata: SeoPageMetadata, options: RenderOptions = {}): string {
@@ -591,6 +597,31 @@ export default class SeoRenderer {
       scripts: normalizeScripts(manifest.scripts),
       styles: normalizeStyles(manifest.styles),
       preloads: normalizePreloads(manifest.preloads),
+    };
+  }
+
+  private hasUsableAssets(manifest: AssetManifest): boolean {
+    const hasScripts = Array.isArray(manifest.scripts) && manifest.scripts.length > 0;
+    const hasStyles = Array.isArray(manifest.styles) && manifest.styles.length > 0;
+    const hasPreloads = Array.isArray(manifest.preloads) && manifest.preloads.length > 0;
+    return hasScripts || hasStyles || hasPreloads;
+  }
+
+  private buildFallbackAssetManifest(): AssetManifest {
+    return {
+      scripts: [
+        {
+          src: '/scripts/main.js',
+          type: 'module',
+        },
+      ],
+      styles: [
+        {
+          href: '/styles/app.css',
+          rel: 'stylesheet',
+        },
+      ],
+      preloads: [],
     };
   }
 


### PR DESCRIPTION
## Summary
- add a fallback asset manifest so the server still injects core scripts and styles when the hashed build output is unavailable
- ensure the fallback manifest only activates when the loaded manifest is missing usable assets

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e56b9bcf508324ad01b060dcd15e31