### PR TITLE
Add Tailwind fallback styles for static template

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -75,11 +75,31 @@
     <link rel="apple-touch-icon" sizes="192x192" href="/icons/icon-192.svg" />
     <!--ASSET_PRELOADS-->
     <!--ASSET_STYLES-->
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.14/dist/tailwind.min.css"
+      data-fallback-style
+    />
+    <link rel="stylesheet" href="/styles/app.css" data-fallback-style />
+    <script type="importmap" data-fallback-importmap>
+      {
+        "imports": {
+          "preact": "https://esm.sh/preact@10.23.2",
+          "preact/hooks": "https://esm.sh/preact@10.23.2/hooks",
+          "htm": "https://esm.sh/htm@3.1.1",
+          "chart.js/auto": "https://esm.sh/chart.js@4.4.6/auto",
+          "three": "https://esm.sh/three@0.170.0",
+          "marked": "https://esm.sh/marked@12.0.2",
+          "lucide-preact": "https://esm.sh/lucide-preact@0.439.0"
+        }
+      }
+    </script>
   </head>
   <body class="min-h-screen bg-slate-950 text-slate-100 antialiased">
     <div id="app" class="min-h-screen"><!--APP_HTML--></div>
 
       <!--APP_STATE-->
       <!--ASSET_SCRIPTS-->
+      <script type="module" src="/scripts/main.js" data-fallback-script></script>
 </body>
 </html>

--- a/src/http/SeoRenderer.ts
+++ b/src/http/SeoRenderer.ts
@@ -391,14 +391,45 @@ export default class SeoRenderer {
       result = result.replace(preloadPlaceholder, preloadTags);
     }
 
+    let injectedStyleTags = '';
     if (result.includes(stylesPlaceholder)) {
-      const styleTags = this.buildStyleTags();
-      result = result.replace(stylesPlaceholder, styleTags);
+      injectedStyleTags = this.buildStyleTags();
+      result = result.replace(stylesPlaceholder, injectedStyleTags);
     }
 
+    let injectedScriptTags = '';
     if (result.includes(scriptsPlaceholder)) {
-      const scriptTags = this.buildScriptTags();
-      result = result.replace(scriptsPlaceholder, scriptTags);
+      injectedScriptTags = this.buildScriptTags();
+      result = result.replace(scriptsPlaceholder, injectedScriptTags);
+    }
+
+    if (injectedStyleTags.trim().length > 0 || injectedScriptTags.trim().length > 0) {
+      result = this.stripFallbackAssets(result, {
+        removeStyles: injectedStyleTags.trim().length > 0,
+        removeScripts: injectedScriptTags.trim().length > 0,
+        removeImportMap: injectedScriptTags.trim().length > 0,
+      });
+    }
+
+    return result;
+  }
+
+  private stripFallbackAssets(
+    html: string,
+    options: { removeStyles: boolean; removeScripts: boolean; removeImportMap: boolean },
+  ): string {
+    let result = html;
+
+    if (options.removeImportMap) {
+      result = result.replace(/[\t ]*<script[^>]*data-fallback-importmap[^>]*>[\s\S]*?<\/script>(?:\r?\n)?/gi, '');
+    }
+
+    if (options.removeStyles) {
+      result = result.replace(/[\t ]*<link[^>]*data-fallback-style[^>]*\/?>(?:\r?\n)?/gi, '');
+    }
+
+    if (options.removeScripts) {
+      result = result.replace(/[\t ]*<script[^>]*data-fallback-script[^>]*><\/script>(?:\r?\n)?/gi, '');
     }
 
     return result;
@@ -616,6 +647,10 @@ export default class SeoRenderer {
         },
       ],
       styles: [
+        {
+          href: 'https://cdn.jsdelivr.net/npm/tailwindcss@3.4.14/dist/tailwind.min.css',
+          rel: 'stylesheet',
+        },
         {
           href: '/styles/app.css',
           rel: 'stylesheet',


### PR DESCRIPTION
## Summary
- add a fallback import map that points to CDN-hosted modules so the static index can run without a build manifest
- strip the fallback import map when real asset bundles are injected to avoid redundant markup
- add a Tailwind CDN stylesheet fallback and register it in the server manifest so static renders keep their styling when build assets are missing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e56dfd24508324834e4a245612ba82