### PR TITLE
Fix statistics build errors

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -100,6 +100,7 @@ export interface Config {
   botToken: string;
   guildId?: string;
   voiceChannelId?: string;
+  timezone?: string;
   port: number;
   ffmpegPath: string;
   outputFormat: 'opus' | 'mp3' | string;
@@ -130,6 +131,11 @@ const config: Config = {
   botToken: process.env.BOT_TOKEN ?? '',
   guildId: process.env.GUILD_ID,
   voiceChannelId: process.env.VOICE_CHANNEL_ID,
+  timezone: (() => {
+    const value = process.env.TIMEZONE ?? '';
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  })(),
   port: parseInteger(process.env.PORT, 3000),
   ffmpegPath: process.env.FFMPEG_PATH || 'ffmpeg',
   outputFormat,

--- a/src/services/VoiceActivityRepository.ts
+++ b/src/services/VoiceActivityRepository.ts
@@ -2915,7 +2915,6 @@ ${limitClause}`;
 
       const queryParams = [...voiceFilters.params, ...textParams];
       const voiceParamCount = voiceFilters.params.length;
-      const textParamOffset = voiceParamCount + 1;
 
       const voiceClause = voiceFilters.clause;
       const adjustedTextClause = hasTextMessages && activityTypes.has('text')
@@ -3574,7 +3573,6 @@ ${limitClause}`;
         if (!channelId) {
           continue;
         }
-        const voiceMinutes = Number(parseNumber(row.voice_minutes).toFixed(2));
         const activityScore = Number(parseNumber(row.activity_score).toFixed(2));
         suggestions.push({
           channelId,


### PR DESCRIPTION
## Summary
- add an optional timezone setting to the shared configuration so statistics code can read it safely
- remove unused variables in the voice activity repository to satisfy TypeScript during builds

## Testing
- npm run build *(fails: missing React/admin dependencies in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e65072af208324bf2d0344328d253f